### PR TITLE
Use correct package name in gax README.md

### DIFF
--- a/clients/gax/README.md
+++ b/clients/gax/README.md
@@ -10,7 +10,7 @@ by adding `gax` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:gax, "~> 0.1.1"}
+    {:google_gax, "~> 0.1.1"}
   ]
 end
 ```

--- a/clients/gax/README.md
+++ b/clients/gax/README.md
@@ -5,7 +5,7 @@ Google API Extensions for Elixir
 ## Installation
 
 If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `gax` to your list of dependencies in `mix.exs`:
+by adding `google_gax` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do


### PR DESCRIPTION
`gax` package doesn't exist in hex.pm
`google_gax` is the correct package name