### PR TITLE
Clean before code generation

### DIFF
--- a/lib/google_apis/generator/elixir_generator.ex
+++ b/lib/google_apis/generator/elixir_generator.ex
@@ -70,6 +70,7 @@ defmodule GoogleApis.Generator.ElixirGenerator do
 
   defp create_directories(token) do
     IO.puts("Creating leading directories")
+    File.rm_rf!(token.base_dir)
     File.mkdir_p!(Path.join(token.base_dir, "api"))
     File.mkdir_p!(Path.join(token.base_dir, "model"))
     token

--- a/scripts/generate_client.sh
+++ b/scripts/generate_client.sh
@@ -19,6 +19,8 @@ pushd $(dirname "$0")/../
 
 export TEMPLATE=gax
 
+git clean -fdx clients
+
 # clean the codegen directory
 # if [ -d .codegen ]; then
 #     rm -rf .codegen

--- a/synth.py
+++ b/synth.py
@@ -21,6 +21,7 @@ import synthtool.log as log
 import synthtool.shell as shell
 import synthtool.sources.git as git
 import logging
+import shutil
 import sys
 
 logging.basicConfig(level=logging.DEBUG)
@@ -49,6 +50,9 @@ if extra_args():
 log.debug(f"Running: {' '.join(command)}")
 
 shell.run(command, cwd=repository)
+
+# clean destination before copying
+shutil.rmtree("clients", ignore_errors=True)
 
 # copy all clients
 s.copy(repository / "clients")

--- a/synth.py
+++ b/synth.py
@@ -30,7 +30,6 @@ repository_url = "https://github.com/googleapis/elixir-google-api.git"
 
 log.debug(f"Cloning {repository_url}.")
 repository = git.clone(repository_url, depth=1)
-shell.run(["git", "clean", "-fdx"], cwd=repository / "clients")
 
 image = "gcr.io/cloud-devrel-public-resources/elixir16"
 generate_command = "scripts/generate_client.sh"


### PR DESCRIPTION
We were leaving old files from the Swagger generator which are no longer necessary.

Also fixes all the failures caused by AndroidPublisher adding a new version. When we create a new directory (v3), the umask from the new directory in the working directory has the files owned by the root docker user. We cannot run `git clean` on that directory from outside the docker image.