### PR TITLE
Fix otp_app name used in the config path

### DIFF
--- a/lib/google_apis/generator/elixir_generator.ex
+++ b/lib/google_apis/generator/elixir_generator.ex
@@ -78,7 +78,7 @@ defmodule GoogleApis.Generator.ElixirGenerator do
 
   defp write_connection(token) do
     scopes = scopes_for(token.rest_description)
-    otp_app = "google_api_#{Macro.underscore(token.rest_description.name)}"
+    otp_app = "google_api_#{token.library_name}"
 
     path = Path.join(token.base_dir, "connection.ex")
     IO.puts("Writing connection.ex.")


### PR DESCRIPTION
In the swagger generator, the `otp_app` uses a snake-cased name of the API with underscores where there are multiple words. For example, the `UrlShortener` API has an `otp_app` of `google_api_url_shortener`. Currently the new generator uses the *API name* which generally concatenates words together without the underscore. So the new generator creates the name `google_api_urlshortener`. See e.g. https://github.com/googleapis/elixir-google-api/pull/1838/files#diff-50cb9b5f2a608a8edf65486a8894bdd3R30

I think we should prefer the earlier version with the underscore because it matches the Elixir namespace (e.g. `GoogleApi.UrlShortener`). So I'm grabbing that value from the token.