### PR TITLE
Quote description content for inclusion in docstrings

### DIFF
--- a/lib/google_apis/generator/elixir_generator/renderer.ex
+++ b/lib/google_apis/generator/elixir_generator/renderer.ex
@@ -38,10 +38,14 @@ defmodule GoogleApis.Generator.ElixirGenerator.Renderer do
     :base_url
   ])
 
-  defp indent_subsequent(nil, _spaces), do: nil
+  defp render_description(nil, _args), do: nil
 
-  defp indent_subsequent(str, spaces) do
+  defp render_description(str, args) do
+    spaces = Keyword.get(args, :indent_subsequent, 0)
     prefix = " " |> List.duplicate(spaces) |> Enum.join()
-    String.replace(str, ~r{(\n+)([^\n])}, "\\1#{prefix}\\2")
+    str
+    |> String.replace("\"\"\"", "\\\"\\\"\\\"")
+    |> String.replace("\\", "\\\\")
+    |> String.replace(~r{(\n+)([^\n])}, "\\1#{prefix}\\2")
   end
 end

--- a/template/elixir/api.ex.eex
+++ b/template/elixir/api.ex.eex
@@ -17,7 +17,7 @@
 
 defmodule <%= namespace %>.Api.<%= api.name %> do
   @moduledoc """
-  <%= indent_subsequent(api.description, 2) %>
+  <%= render_description(api.description, indent_subsequent: 2) %>
   """
 
   alias <%= namespace %>.Connection
@@ -25,14 +25,14 @@ defmodule <%= namespace %>.Api.<%= api.name %> do
 
   <%= for endpoint <- api.endpoints do %>
   @doc """
-  <%= indent_subsequent(endpoint.description, 2) %>
+  <%= render_description(endpoint.description, indent_subsequent: 2) %>
 
   ## Parameters
 
   *   `connection` (*type:* `<%= namespace %>.Connection.t`) - Connection to server<%= for parameter <- endpoint.required_parameters do %>
-  *   `<%= parameter.variable_name %>` (*type:* `<%= parameter.type.typespec %>`) - <%= indent_subsequent(parameter.description, 6) %><% end %>
+  *   `<%= parameter.variable_name %>` (*type:* `<%= parameter.type.typespec %>`) - <%= render_description(parameter.description, indent_subsequent: 6) %><% end %>
   *   `optional_params` (*type:* `keyword()`) - Optional parameters<%= for parameter <- global_optional_parameters ++ endpoint.optional_parameters do %>
-      *   `:<%= parameter.name %>` (*type:* `<%= parameter.type.typespec %>`) - <%= indent_subsequent(parameter.description, 10) %><% end %>
+      *   `:<%= parameter.name %>` (*type:* `<%= parameter.type.typespec %>`) - <%= render_description(parameter.description, indent_subsequent: 10) %><% end %>
   *   `opts` (*type:* `keyword()`) - Call options
 
   ## Returns

--- a/template/elixir/model.ex.eex
+++ b/template/elixir/model.ex.eex
@@ -17,11 +17,11 @@
 
 defmodule <%= namespace %>.Model.<%= model.name %> do
   @moduledoc """
-  <%= indent_subsequent(model.description, 2) %>
+  <%= render_description(model.description, indent_subsequent: 2) %>
 
   ## Attributes
   <%= for property <- model.properties do %>
-  *   `<%= property.name %>` (*type:* `<%= property.type.typespec %>`, *default:* `<%= GoogleApis.Generator.ElixirGenerator.Model.value_string(property.default) %>`) - <%= indent_subsequent(property.description, 6) %><% end %>
+  *   `<%= property.name %>` (*type:* `<%= property.type.typespec %>`, *default:* `<%= GoogleApis.Generator.ElixirGenerator.Model.value_string(property.default) %>`) - <%= render_description(property.description, indent_subsequent: 6) %><% end %>
   """
 
   use GoogleApi.Gax.ModelBase


### PR DESCRIPTION
Add some quoting when rendering description text into docstrings. Specifically:

* If triple quotes appear in the description, we backslash-escape each one. This prevents the triple quote from breaking the docstring syntax.
* If a literal backslash appears in the description, we backslash-escape it also, to preserve it in the docstring.

This should fix #1519.