### PR TITLE
feat(gax): Generate x-goog-api-client header

### DIFF
--- a/clients/gax/lib/google_api/gax/connection.ex
+++ b/clients/gax/lib/google_api/gax/connection.ex
@@ -33,7 +33,6 @@ defmodule GoogleApi.Gax.Connection do
         )
       )
 
-      plug(Tesla.Middleware.Headers, [{"user-agent", "Elixir"}])
       plug(Tesla.Middleware.EncodeJson, engine: Poison)
 
       @doc """
@@ -41,15 +40,15 @@ defmodule GoogleApi.Gax.Connection do
 
       ## Parameters
 
-      - token (String): Bearer token
+      *   `token` (*type:* `String.t`) - Bearer token
 
       ## Returns
 
-      Tesla.Env.client
+      *   `Tesla.Env.client`
       """
       @spec new(String.t()) :: Tesla.Client.t()
       def new(token) when is_binary(token) do
-        Tesla.build_client([
+        Tesla.client([
           {Tesla.Middleware.Headers, [{"authorization", "Bearer #{token}"}]}
         ])
       end
@@ -59,12 +58,12 @@ defmodule GoogleApi.Gax.Connection do
 
       ## Parameters
 
-      - token_fetcher (function arity of 1): Callback which provides an OAuth2 token
-        given a list of scopes
+      *   `token_fetcher` (*type:* `list(String.t()) -> String.t()`) - Callback
+          which provides an OAuth2 token given a list of scopes
 
       ## Returns
 
-      Tesla.Env.client
+      *   `Tesla.Env.client`
       """
       @spec new((list(String.t()) -> String.t())) :: Tesla.Client.t()
       def new(token_fetcher) when is_function(token_fetcher) do
@@ -75,21 +74,22 @@ defmodule GoogleApi.Gax.Connection do
       @doc """
       Configure an authless client connection
 
-      # Returns
+      ## Returns
 
-      Tesla.Client.t
+      *   `Tesla.Env.client`
       """
       @spec new() :: Tesla.Client.t()
       def new do
-        Tesla.build_client([])
+        Tesla.client([])
       end
 
       @doc """
       Execute a request on this connection
 
-      # Returns
+      ## Returns
 
-      Tesla.Env
+      *   `{:ok, Tesla.Env.t}` - If the call was successful
+      *   `{:error, reason}` - If the call failed
       """
       @spec execute(Tesla.Client.t(), GoogleApi.Gax.Request.t()) :: {:ok, Tesla.Env.t()}
       def execute(connection, request) do
@@ -108,7 +108,7 @@ defmodule GoogleApi.Gax.Connection do
   def build_request(request) do
     [url: request.url, method: request.method]
     |> build_query(request.query)
-    |> build_headers(request.header)
+    |> build_headers(request.header, request.library_version)
     |> build_body(request.body, request.file)
   end
 
@@ -118,10 +118,38 @@ defmodule GoogleApi.Gax.Connection do
     Keyword.put(output, :query, query_params)
   end
 
-  defp build_headers(output, []), do: output
+  @gax_version GoogleApi.Gax.MixProject.project() |> Keyword.get(:version, "")
 
-  defp build_headers(output, header_params) do
-    Keyword.put(output, :headers, header_params)
+  defp build_headers(output, header_params, library_version) do
+    {other_api_client, other_headers} = find_api_client_headers(header_params, [], [])
+
+    api_client =
+      Enum.join(
+        [
+          "gl-elixir/#{System.version()}",
+          "gax/#{@gax_version}",
+          "gdcl/#{library_version}"
+          | other_api_client
+        ],
+        " "
+      )
+
+    headers = [{"x-goog-api-client", api_client} | other_headers]
+    Keyword.put(output, :headers, headers)
+  end
+
+  defp find_api_client_headers([], found, other_headers) do
+    {Enum.reverse(found), Enum.reverse(other_headers)}
+  end
+
+  defp find_api_client_headers([{name, value} | remaining], found, other_headers) do
+    normalized_name = name |> to_string() |> String.downcase()
+
+    if normalized_name == "x-goog-api-client" do
+      find_api_client_headers(remaining, [value | found], other_headers)
+    else
+      find_api_client_headers(remaining, found, [{name, value} | other_headers])
+    end
   end
 
   # If no body or file fields and the request is a POST, set an empty body

--- a/clients/gax/lib/google_api/gax/connection.ex
+++ b/clients/gax/lib/google_api/gax/connection.ex
@@ -118,7 +118,7 @@ defmodule GoogleApi.Gax.Connection do
     Keyword.put(output, :query, query_params)
   end
 
-  @gax_version GoogleApi.Gax.MixProject.project() |> Keyword.get(:version, "")
+  @gax_version Mix.Project.config() |> Keyword.get(:version, "")
 
   defp build_headers(output, header_params, library_version) do
     {other_api_client, other_headers} = find_api_client_headers(header_params, [], [])

--- a/clients/gax/lib/google_api/gax/data_wrapper.ex
+++ b/clients/gax/lib/google_api/gax/data_wrapper.ex
@@ -19,12 +19,12 @@ defmodule GoogleApi.Gax.DataWrapper do
   An endpoint response may be declared as type "Pet" and "data-wrapped" which
   means the response would have an outer object with a single "data" key:
 
-  {
-    "data": { // real pet data
-      "id": 123,
-      "name": "Fido"
-    }
-  }
+      {
+        "data": { // real pet data
+          "id": 123,
+          "name": "Fido"
+        }
+      }
   """
 
   defstruct [:data]

--- a/clients/gax/lib/google_api/gax/request.ex
+++ b/clients/gax/lib/google_api/gax/request.ex
@@ -19,7 +19,7 @@ defmodule GoogleApi.Gax.Request do
 
   @path_template_regex ~r/{(\+?[^}]+)}/i
 
-  defstruct method: :get, url: "", body: [], query: [], file: [], header: []
+  defstruct method: :get, url: "", body: [], query: [], file: [], header: [], library_version: ""
 
   @type param_location :: :body | :query | :header | :file
   @type method :: :head | :get | :delete | :trace | :options | :post | :put | :patch
@@ -29,12 +29,33 @@ defmodule GoogleApi.Gax.Request do
           body: keyword(),
           query: keyword(),
           file: keyword(),
-          header: keyword()
+          header: keyword(),
+          library_version: String.t()
         }
 
   @spec new() :: GoogleApi.Gax.Request.t()
   def new do
     %__MODULE__{}
+  end
+
+  @spec library_version(GoogleApi.Gax.Request.t()) :: {:ok, String.t()} | :error
+  def library_version(request), do: Map.fetch(request, :library_version)
+
+  @doc """
+  Specify the library version when building a request
+
+  ## Parameters
+
+  *   `request` (*type:* `GoogleApi.Gax.Request.t`) - Collected request options
+  *   `version` (*type:* `String`) - Library version
+
+  ## Returns
+
+  *   `GoogleApi.Gax.Request.t`
+  """
+  @spec library_version(GoogleApi.Gax.Request.t(), String.t()) :: GoogleApi.Gax.Request.t()
+  def library_version(request, version) do
+    %{request | library_version: version}
   end
 
   @spec method(GoogleApi.Gax.Request.t()) :: {:ok, atom()} | :error
@@ -45,12 +66,12 @@ defmodule GoogleApi.Gax.Request do
 
   ## Parameters
 
-  - request (Map) - Collected request options
-  - m (String) - Request method
+  *   `request` (*type:* `GoogleApi.Gax.Request.t`) - Collected request options
+  *   `m` (*type:* `String`) - Request method
 
   ## Returns
 
-  Map
+  *   `GoogleApi.Gax.Request.t`
   """
   @spec method(GoogleApi.Gax.Request.t(), atom()) :: GoogleApi.Gax.Request.t()
   def method(request, m) do
@@ -61,16 +82,16 @@ defmodule GoogleApi.Gax.Request do
   def url(request), do: Map.fetch(request, :url)
 
   @doc """
-  Specify the request method when building a request
+  Specify the request URL when building a request
 
   ## Parameters
 
-  - request (Map) - Collected request options
-  - u (String) - Request URL
+  *   `request` (*type:* `GoogleApi.Gax.Request.t`) - Collected request options
+  *   `u` (*type:* `String`) - Request URL
 
   ## Returns
 
-  Map
+  *   `GoogleApi.Gax.Request.t`
   """
   @spec url(GoogleApi.Gax.Request.t(), String.t(), map()) :: GoogleApi.Gax.Request.t()
   def url(request, u, replacements) do
@@ -100,13 +121,13 @@ defmodule GoogleApi.Gax.Request do
 
   ## Parameters
 
-  - request (Map) - Collected request options
-  - definitions (Map) - Map of parameter name to parameter location.
-  - options (KeywordList) - The provided optional parameters
+  *   `request` (*type:* `GoogleApi.Gax.Request.t`) - Collected request options
+  *   `definitions` (*type:* `Map`) - Map of parameter name to parameter location
+  *   `options` (*type:* `keyword()`) - The provided optional parameters
 
   ## Returns
 
-  Map
+  *   `GoogleApi.Gax.Request.t`
   """
   @spec add_optional_params(
           GoogleApi.Gax.Request.t(),
@@ -132,14 +153,14 @@ defmodule GoogleApi.Gax.Request do
 
   ## Parameters
 
-  - request (Map) - Collected request options
-  - location (atom) - Where to put the parameter
-  - key (atom) - The name of the parameter
-  - value (any) - The value of the parameter
+  *   `request` (*type:* `GoogleApi.Gax.Request.t`) - Collected request options
+  *   `location` (*type:* `atom()`) - Where to put the parameter
+  *   `key` (*type:* `atom()`) - The name of the parameter
+  *   `value` (*type:* `any()`) - The value of the parameter
 
   ## Returns
 
-  Map
+  *   `GoogleApi.Gax.Request.t`
   """
   @spec add_param(GoogleApi.Gax.Request.t(), param_location(), atom(), any()) ::
           GoogleApi.Gax.Request.t()

--- a/clients/gax/lib/google_api/gax/response.ex
+++ b/clients/gax/lib/google_api/gax/response.ex
@@ -24,17 +24,16 @@ defmodule GoogleApi.Gax.Response do
 
   ## Parameters
 
-  - response ({:ok, Tesla.Env} | {:error, reason}) - The response object
-  - struct (struct | false) - The shape of the struct to deserialize into. If false, returns the Tesla response.
-  - opts (KeywordList) - [optional] Optional parameters
-    - :dataWrapped (boolean()): If true, the remove the wrapping "data" field. Defaults to false.
-    - :decode (boolean()): If false, returns the entire reponse. Defaults to true.
-    - :struct (module)
+  *   `response` (*type:* `{:ok, Tesla.Env.t} | {:error, reason}`) - The response object
+  *   `opts` (*type:* `keyword()`) - [optional] Optional parameters
+      *   `:dataWrapped` (*type:* `boolean()`) - If true, the remove the wrapping "data" field. Defaults to false.
+      *   `:decode` (*type:* `boolean()`) - If false, returns the entire reponse. Defaults to true.
+      *   `:struct` (*type:* `module`)
 
   ## Returns
 
-  {:ok, struct} on success
-  {:error, info} on failure
+  *   `{:ok, struct()}` on success
+  *   `{:error, Tesla.Env.t}` on failure
   """
   @spec decode({:ok, Tesla.Env.t()}, keyword()) :: {:ok, struct()} | {:error, Tesla.Env.t()}
   def decode(env, opts \\ [])

--- a/clients/gax/mix.exs
+++ b/clients/gax/mix.exs
@@ -1,7 +1,7 @@
 defmodule GoogleApi.Gax.MixProject do
   use Mix.Project
 
-  @version "0.1.3"
+  @version "0.2.0"
 
   def project do
     [
@@ -26,7 +26,7 @@ defmodule GoogleApi.Gax.MixProject do
 
   defp deps() do
     [
-      {:tesla, "~> 1.0"},
+      {:tesla, "~> 1.2"},
       {:poison, ">= 1.0.0 and < 4.0.0"},
       {:ex_doc, "~> 0.16", only: :dev},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false}
@@ -42,7 +42,7 @@ defmodule GoogleApi.Gax.MixProject do
   defp package() do
     [
       files: ["lib", "mix.exs", "README*", "LICENSE"],
-      maintainers: ["Jeff Ching"],
+      maintainers: ["Jeff Ching", "Daniel Azuma"],
       licenses: ["Apache 2.0"],
       links: %{
         "GitHub" =>

--- a/clients/gax/test/gax/api_test.exs
+++ b/clients/gax/test/gax/api_test.exs
@@ -26,7 +26,15 @@ defmodule Gax.ApiTest do
   """
 
   test "basic request" do
-    mock(fn %{method: :get, url: "https://example.com/v1/stores/store-1/pets"} ->
+    elixir_version = System.version()
+    gax_version = Application.spec(:google_gax, :vsn)
+    api_client = "gl-elixir/#{elixir_version} gax/#{gax_version} gdcl/1.2.3"
+
+    mock(fn %{
+              method: :get,
+              url: "https://example.com/v1/stores/store-1/pets",
+              headers: [{"x-goog-api-client", ^api_client}]
+            } ->
       %Tesla.Env{status: 200, body: @pets_json}
     end)
 

--- a/clients/gax/test/gax/request_test.exs
+++ b/clients/gax/test/gax/request_test.exs
@@ -30,6 +30,14 @@ defmodule Gax.RequestTest do
     assert :post == request.method
   end
 
+  test "sets library version" do
+    request =
+      Request.new()
+      |> Request.library_version("1.2.3")
+
+    assert "1.2.3" == request.library_version
+  end
+
   test "sets url" do
     request =
       Request.new()

--- a/clients/gax/test/test_client/api/pets.ex
+++ b/clients/gax/test/test_client/api/pets.ex
@@ -25,6 +25,7 @@ defmodule TestClient.Api.Pets do
     request =
       Request.new()
       |> Request.method(:get)
+      |> Request.library_version("1.2.3")
       |> Request.url("/v1/stores/{store}/pets", %{
         "store" => URI.encode_www_form(store)
       })


### PR DESCRIPTION
The main change here is proper support for the `x-goog-api-client` header. It includes:
`gl-elixir/#{ELIXIR_VERSION} gax/#{GAX_VERSION} gdcl/#{LIBRARY_VERSION}` where ELIXIR_VERSION is obtained by calling `System.version()` at runtime, and GAX_VERSION is obtained by calling `Mix.Project.config()` at _compile time_.

The LIBRARY_VERSION will need to be passed in by the downstream generated library. To this end, I added `library_version` as a field of `GoogleApi.Gax.Request`. It defaults to the empty string, which generates the correct `gdcl/` syntax for unknown version. (This will be the behavior when an older client uses this newer gax.) The next step will be to modify the generator to set this field when generating request structs. (Generated libraries will determine their proper value by calling `Mix.Project.config()` at compile time.)

This PR also:

* Removes the "user-agent" header
* Replaces the deprecated `Tesla.build_client()` with the preferred replacement `Tesla.client()`, and updates the Tesla dependency to `~> 1.2` to ensure a version of Tesla that supports the preferred API.
* Updates docstrings to be in line with the formatting fixes we made earlier for types, etc. (This includes some of the docstrings _generated_ by calling `use GoogleApi.Gax.Connection` from generated code.)

The version of gax is bumped to 0.2.0 to reflect the addition of `library_version` to the Request struct. My next step is to modify the generated code to set this value, and gax dependency from generated libraries will need to be updated to `~> 0.2` accordingly.
