### PR TITLE
fix(generator): Version bump from actual hex version

### DIFF
--- a/lib/google_apis/generator.ex
+++ b/lib/google_apis/generator.ex
@@ -128,6 +128,6 @@ defmodule GoogleApis.Generator do
 
   defp version_requirement_string(str) do
     v = Version.parse!(str)
-    "~> #{v.major}.#{v.minor}"
+    "#{v.major}.#{v.minor}"
   end
 end

--- a/lib/google_apis/generator.ex
+++ b/lib/google_apis/generator.ex
@@ -16,6 +16,8 @@ defmodule GoogleApis.Generator do
   @callback generate_client(GoogleApis.ApiConfig.t()) :: any()
   alias GoogleApis.ApiConfig
 
+  require Logger
+
   def bump_version(api_config) do
     version = api_config |> current_hex_version() |> bump_version_string()
     set_mix_version(api_config, version)
@@ -37,7 +39,12 @@ defmodule GoogleApis.Generator do
          [%{"version" => version} | _] <- Map.get(info, "releases") do
       version
     else
-      _ -> current_mix_version(api_config)
+      _ ->
+        Logger.warn(
+          "Failed to get hex version for #{package_name}. Falling back on reading mix.exs."
+        )
+
+        current_mix_version(api_config)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -48,6 +48,7 @@ defmodule GoogleApis.Mixfile do
       {:tesla, "~> 1.0"},
       {:oauth2, "~> 0.9"},
       {:temp, "~> 0.4"},
+      {:jason, "~> 1.1"},
       {:poison, "~> 3.1"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -4,6 +4,7 @@
   "google_gax": {:hex, :google_gax, "0.1.3", "3455b58188803a554cc07447268af1da1cf35ca280267e297c677d005d1b2117", [:mix], [{:poison, ">= 1.0.0 and < 4.0.0", [hex: :poison, repo: "hexpm", optional: false]}, {:tesla, "~> 1.0", [hex: :tesla, repo: "hexpm", optional: false]}], "hexpm"},
   "hackney": {:hex, :hackney, "1.15.1", "9f8f471c844b8ce395f7b6d8398139e26ddca9ebc171a8b91342ee15a19963f4", [:rebar3], [{:certifi, "2.5.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "~>1.1", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.4", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "6.0.0", "689c46cbcdf3524c44d5f3dde8001f364cd7608a99556d8fbd8239a5798d4c10", [:rebar3], [{:unicode_util_compat, "0.4.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
+  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm"},


### PR DESCRIPTION
This rewrites the version bump mechanism to solve two issues.
1. It calls hex to get the current version from which to bump, instead of using the current value from mix.exs. This is to prevent "multiple bumps". (Note that if the hex call fails, it will still fall back to reading mix.exs.)
2. It updates both mix.exs and the README.md. This is important because README.md is now generated and its version requirement comes from mix.exs. The two need to stay in sync. (Thus, this prevents a "version update loop" in which the version is bumped in mix.exs, and then the next time generation is run, README.md gets updated, which in turn triggers another version bump.)