### PR TITLE
chore(generator): Add firestore v1 and remove obsolete replicapool from api list

### DIFF
--- a/config/apis.json
+++ b/config/apis.json
@@ -296,6 +296,11 @@
   },
   {
     "version": "v1",
+    "name": "Firestore",
+    "url": "https://firestore.googleapis.com/$discovery/rest?version=v1"
+  },
+  {
+    "version": "v1",
     "name": "Fitness",
     "url": "https://www.googleapis.com/discovery/v1/apis/fitness/v1/rest"
   },
@@ -468,11 +473,6 @@
     "version": "v1beta1",
     "name": "Redis",
     "url": "https://redis.googleapis.com/$discovery/rest?version=v1beta1"
-  },
-  {
-    "version": "v1beta1",
-    "name": "ReplicaPool",
-    "url": "https://www.googleapis.com/discovery/v1/apis/replicapool/v1beta1/rest"
   },
   {
     "version": "v1",


### PR DESCRIPTION
Some initial edits to the api list:

* Add Firestore V1 (because I need it for a demo). This means Firestore will now include both V1 and V1beta1.
* Remove ReplicaPool which is long deprecated with a GA replacement, and I don't think we should generate it any longer.

I'm starting to look into a full refresh of the list, but first I want to update the generator to generate the remaining files, so we can let the generator create new libraries on its own.