### PR TITLE
fix(generator): Limit hex description field to 299 characters

### DIFF
--- a/lib/google_apis/generator/elixir_generator.ex
+++ b/lib/google_apis/generator/elixir_generator.ex
@@ -161,7 +161,7 @@ defmodule GoogleApis.Generator.ElixirGenerator do
 
   defp generate_hex_description(rest_info) do
     api_title = api_title_for(rest_info)
-    description_start = "Client library for #{api_title} from Google."
+    description_start = "#{api_title} client library."
     rest_description = description_for(rest_info)
 
     if String.length(description_start) + String.length(rest_description) > 298 do

--- a/lib/google_apis/generator/elixir_generator.ex
+++ b/lib/google_apis/generator/elixir_generator.ex
@@ -115,9 +115,8 @@ defmodule GoogleApis.Generator.ElixirGenerator do
     path = Path.join(token.root_dir, "mix.exs")
     IO.puts("Writing mix.exs")
 
-    api_title = api_title_for(token.rest_description)
+    description = generate_hex_description(token.rest_description)
     docs_link = docs_link_for(token.rest_description)
-    description = description_for(token.rest_description)
     version = version_from_mix_exs(path)
 
     File.write!(
@@ -125,7 +124,6 @@ defmodule GoogleApis.Generator.ElixirGenerator do
       Renderer.mix_exs(
         token.root_namespace,
         token.library_name,
-        api_title,
         docs_link,
         version,
         description
@@ -159,6 +157,18 @@ defmodule GoogleApis.Generator.ElixirGenerator do
     )
 
     token
+  end
+
+  defp generate_hex_description(rest_info) do
+    api_title = api_title_for(rest_info)
+    description_start = "Client library for #{api_title} from Google."
+    rest_description = description_for(rest_info)
+
+    if String.length(description_start) + String.length(rest_description) > 298 do
+      description_start
+    else
+      "#{description_start} #{rest_description}"
+    end
   end
 
   defp scopes_for(%{auth: nil}), do: []

--- a/lib/google_apis/generator/elixir_generator/renderer.ex
+++ b/lib/google_apis/generator/elixir_generator/renderer.ex
@@ -41,7 +41,6 @@ defmodule GoogleApis.Generator.ElixirGenerator.Renderer do
   EEx.function_from_file(:def, :mix_exs, Path.expand("./template/elixir/mix.exs.eex"), [
     :namespace,
     :library_name,
-    :api_title,
     :docs_link,
     :version,
     :description

--- a/template/elixir/mix.exs.eex
+++ b/template/elixir/mix.exs.eex
@@ -48,7 +48,7 @@ defmodule <%= namespace %>.Mixfile do
 
   defp description() do
     """
-    Client library for <%= api_title %> from Google. <%= description %>
+    <%= description %>
     """
   end
 


### PR DESCRIPTION
Fixes #2433 by changing the description field in the generated mix.exs to omit the "long" description from the discovery doc if it would have caused the field to exceed 299 characters.

Note: the first part of the description wording was also changed from `Client library for <%= api_title %> from Google` to `<%= api_title %> client library` which should be a bit less awkward. Note that #2440 makes the same change in the generated readme.