### PR TITLE
chore(firestore): Bump firestore version

### DIFF
--- a/clients/firestore/README.md
+++ b/clients/firestore/README.md
@@ -12,7 +12,7 @@ Install this package from [Hex](https://hex.pm) by adding
 
 ```elixir
 def deps do
-  [{:google_api_firestore, "~> 0.7"}]
+  [{:google_api_firestore, "~> 0.8"}]
 end
 ```
 

--- a/clients/firestore/mix.exs
+++ b/clients/firestore/mix.exs
@@ -18,7 +18,7 @@
 defmodule GoogleApi.Firestore.Mixfile do
   use Mix.Project
 
-  @version "0.7.0"
+  @version "0.8.0"
 
   def project() do
     [


### PR DESCRIPTION
The last autosynth added v1 files but didn't bump the package version.