### PR TITLE
Add support for Poison 4

### DIFF
--- a/clients/gax/lib/google_api/gax/data_wrapper.ex
+++ b/clients/gax/lib/google_api/gax/data_wrapper.ex
@@ -45,7 +45,7 @@ defmodule GoogleApi.Gax.DataWrapper do
   @spec decode(GoogleApi.Gax.DataWrapper.t(), keyword()) :: any()
   def decode(data_wrapper, options) do
     struct = options[:struct]
-    Poison.Decode.decode(data_wrapper.data, as: struct)
+    GoogleApi.Gax.ModelBase.poison_transform(data_wrapper.data, %{as: struct})
   end
 end
 

--- a/clients/gax/mix.exs
+++ b/clients/gax/mix.exs
@@ -1,7 +1,7 @@
 defmodule GoogleApi.Gax.MixProject do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.3.0"
 
   def project do
     [
@@ -27,7 +27,7 @@ defmodule GoogleApi.Gax.MixProject do
   defp deps() do
     [
       {:tesla, "~> 1.2"},
-      {:poison, ">= 1.0.0 and < 4.0.0"},
+      {:poison, ">= 3.0.0 and < 5.0.0"},
       {:ex_doc, "~> 0.16", only: :dev},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false}
     ]


### PR DESCRIPTION
Modify gax so it will run with either Poison 3 or Poison 4. Fixes #1232.

We check at compile time for `Poison.Decode.decode/2` which exists in Poison 3 but was renamed to `Poison.Decode.transform/2` in Poison 4, and generate different versions of the function `GoogleApis.Gax.ModelBase.poison_transform/2` in response, to call the appropriate Poison function.

This also includes two Poison 4 specific fixes:
* Poison's options are supposed to be of type `Map`. Most calls perform automatic conversion from `Keyword`, but `Poison.Decode.transform` doesn't. So we alter our call points accordingly.
* Poison 4 has an apparent known issue (https://github.com/devinus/poison/issues/191) where struct transformation happens twice on substructs (which causes failures because the transformation code doesn't properly handle the case when an already-transformed struct is given as input). We include a workaround to prevent the second call to `transform` if the input is already a struct.
