### PR TITLE
Generate function that uploads from iodata

### DIFF
--- a/test/google_apis/generator/elixir_generator/endpoint_test.exs
+++ b/test/google_apis/generator/elixir_generator/endpoint_test.exs
@@ -254,11 +254,15 @@ defmodule GoogleApis.Generator.ElixirGenerator.EndpointTest do
       Poison.decode!(@media_upload, as: %RestMethod{})
       |> Endpoint.from_discovery_method(context)
 
-    assert 3 == length(endpoints)
-    [base, resumable, simple] = endpoints
+    assert 4 == length(endpoints)
+    [base, iodata, resumable, simple] = endpoints
     assert "storage_objects_insert" == base.name
     assert "/v1/storage/b/{bucket}/o" == base.path
     assert 1 == length(base.optional_parameters)
+
+    assert "storage_objects_insert_iodata" == iodata.name
+    assert "/upload/storage/v1/b/{bucket}/o" == iodata.path
+    assert 0 == length(iodata.optional_parameters)
 
     assert "storage_objects_insert_resumable" == resumable.name
     assert "/resumable/upload/storage/v1/b/{bucket}/o" == resumable.path


### PR DESCRIPTION
Currently, upload operations are generating three functions:
* the basic upload (which translates to metadata-only upload) using the base URL. For example `storage_objects_insert`.
* "simple" upload (which actually translates to multipart upload, providing both metadata and content, but pulling the content from a file) using the "simple" mediaUpload URL. For example `storage_objects_insert_simple`.
* "resumable" upload which uses the "resumable" mediaUpload URL. For example `storage_objects_insert_resumable`.

We're getting requests (e.g. #972) to be able to upload directly from memory rather than having to write to a file. So I'm causing the generation of a fourth function, called (for example) `storage_objects_insert_iodata`, which is like the simple case but takes an [iodata](https://hexdocs.pm/elixir/IO.html#module-io-data) instead of a filename. I've tested this against GCS.