### PR TITLE
Handle array as toplevel response

### DIFF
--- a/clients/gax/README.md
+++ b/clients/gax/README.md
@@ -10,7 +10,7 @@ by adding `google_gax` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:google_gax, "~> 0.3.1"}
+    {:google_gax, "~> 0.3.0"}
   ]
 end
 ```

--- a/clients/gax/README.md
+++ b/clients/gax/README.md
@@ -10,7 +10,7 @@ by adding `google_gax` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:google_gax, "~> 0.1.1"}
+    {:google_gax, "~> 0.3.1"}
   ]
 end
 ```

--- a/clients/gax/lib/google_api/gax/response.ex
+++ b/clients/gax/lib/google_api/gax/response.ex
@@ -63,6 +63,10 @@ defmodule GoogleApi.Gax.Response do
     Poison.decode(body, as: %DataWrapper{}, struct: struct)
   end
 
+  defp do_decode("[" <> _ = body, _data_wrapped, struct) do
+    Poison.decode(body, as: [struct])
+  end
+
   defp do_decode(body, _data_wrapped, struct) do
     Poison.decode(body, as: struct)
   end

--- a/clients/gax/mix.exs
+++ b/clients/gax/mix.exs
@@ -1,7 +1,7 @@
 defmodule GoogleApi.Gax.MixProject do
   use Mix.Project
 
-  @version "0.3.1"
+  @version "0.3.0"
 
   def project do
     [

--- a/clients/gax/mix.exs
+++ b/clients/gax/mix.exs
@@ -1,7 +1,7 @@
 defmodule GoogleApi.Gax.MixProject do
   use Mix.Project
 
-  @version "0.3.0"
+  @version "0.3.1"
 
   def project do
     [

--- a/clients/gax/test/gax/response_test.exs
+++ b/clients/gax/test/gax/response_test.exs
@@ -27,6 +27,15 @@ defmodule Gax.ResponseTest do
     assert {:ok, %{"foo" => "bar"}} = Response.decode({:ok, env})
   end
 
+  test "handles other 200 responses with array" do
+    env = %Tesla.Env{
+      status: 200,
+      body: "[{\"foo\": \"bar\"}]"
+    }
+
+    assert {:ok, [%{"foo" => "bar"}]} = Response.decode({:ok, env})
+  end
+
   test "handles other 200 responses without body" do
     env = %Tesla.Env{
       status: 200,
@@ -44,6 +53,16 @@ defmodule Gax.ResponseTest do
 
     assert {:ok, report} = Response.decode({:ok, env}, struct: %Pet{})
     assert %Pet{} = report
+  end
+
+  test "handles other 200 responses with struct array" do
+    env = %Tesla.Env{
+      status: 200,
+      body: "[{\"calloutStatusRate\": []}]"
+    }
+
+    assert {:ok, report} = Response.decode({:ok, env}, struct: %Pet{})
+    assert [%Pet{}] = report
   end
 
   test "handles other 200 responses with data wrapped struct" do


### PR DESCRIPTION
Handles the case when a call declares its return type as a particular struct, but the actual returned JSON is an array of that struct. Detects the array when deserializing (i.e. checks whether the first character is `[`) and alters the deserialization type accordingly.

This sometimes happens when the underlying RPC actually returns a stream. The REST version of such an RPC translates this to an array of data structures, but the discovery doc doesn't reflect that, so the generated code still thinks the return type is just a single struct. Fixes #1231 which reports one such case (Firestore's documents.runQuery call).