### PR TITLE
Update builds for synthtool change, and remove SearchConsole from API list

### DIFF
--- a/config/apis.json
+++ b/config/apis.json
@@ -716,11 +716,6 @@
   },
   {
     "version": "v1",
-    "url": "https://searchconsole.googleapis.com/$discovery/rest?version=v1",
-    "name": "SearchConsole"
-  },
-  {
-    "version": "v1",
     "url": "https://securitycenter.googleapis.com/$discovery/rest?version=v1",
     "name": "SecurityCenter"
   },

--- a/synth.py
+++ b/synth.py
@@ -31,7 +31,7 @@ s.metadata.set_track_obsolete_files(False)  # TODO: enable again.
 repository_url = "https://github.com/googleapis/elixir-google-api.git"
 
 log.debug(f"Cloning {repository_url}.")
-repository = git.clone(repository_url, depth=1)
+repository = git.clone(repository_url)
 
 image = "gcr.io/cloud-devrel-public-resources/elixir19"
 generate_command = "scripts/generate_client.sh"


### PR DESCRIPTION
* Builds are broken because https://github.com/googleapis/synthtool/pull/370 removed the `depth=` argument. Fixed.
* SearchConsole has been failing because the discovery doc was removed. Removed it from the list.