### PR TITLE
fix: shorten double-underscores in model class references

### DIFF
--- a/lib/google_apis/generator/elixir_generator/resource_context.ex
+++ b/lib/google_apis/generator/elixir_generator/resource_context.ex
@@ -32,7 +32,7 @@ defmodule GoogleApis.Generator.ElixirGenerator.ResourceContext do
   """
   @spec struct_name(t, String.t()) :: String.t()
   def struct_name(context, name) do
-    "#{context.namespace}.Model.#{name}"
+    "#{context.namespace}.Model.#{Macro.camelize(name)}"
   end
 
   @doc """
@@ -46,7 +46,7 @@ defmodule GoogleApis.Generator.ElixirGenerator.ResourceContext do
   """
   @spec typespec(t, String.t()) :: String.t()
   def typespec(context, name) do
-    "#{context.namespace}.Model.#{name}.t"
+    "#{context.namespace}.Model.#{Macro.camelize(name)}.t"
   end
 
   defp default_name(%{property: nil}), do: "Unknown"


### PR DESCRIPTION
Fixes #2434 

MachineLearning is affected, possibly one or two others. The issue involves types that are declared in the discovery doc using double-underscores (e.g. `GoogleCloudMlV1__ExplainRequest`). Model generation currently pushes these names through `Macro.camelize/1`, which shortens double-underscores to single-underscores. However, Api generation is not currently doing so for typespecs and references to those type modules, resulting in those references retaining the double underscores and thus failing to compile. This PR pushes those names through `Macro.camelize/1` to match the model definitions.

The original idea in #2434 was to eliminate the underscores in the module names altogether. (This was the behavior of the original discovery-openapi converter and swagger generator.) Unfortunately, I think that ship has long since sailed, and at this point we should probably keep the underscores to avoid breaking users.