### PR TITLE
fix: dedup generated model and api filenames

### DIFF
--- a/lib/google_apis/generator/elixir_generator/api.ex
+++ b/lib/google_apis/generator/elixir_generator/api.ex
@@ -19,11 +19,12 @@ defmodule GoogleApis.Generator.ElixirGenerator.Api do
 
   @type t :: %__MODULE__{
           :name => String.t(),
+          :filename => String.t(),
           :description => String.t(),
           :endpoints => list(Endpoint.t())
         }
 
-  defstruct [:name, :description, :endpoints]
+  defstruct [:name, :filename, :description, :endpoints]
 
   @doc """
   Returns the name of the file that should be generated.

--- a/lib/google_apis/generator/elixir_generator/model.ex
+++ b/lib/google_apis/generator/elixir_generator/model.ex
@@ -19,12 +19,13 @@ defmodule GoogleApis.Generator.ElixirGenerator.Model do
 
   @type t :: %__MODULE__{
           :name => String.t(),
+          :filename => String.t(),
           :description => String.t(),
           :properties => list(Property.t()),
           :schema => JsonSchema.t()
         }
 
-  defstruct [:name, :description, :properties, :schema]
+  defstruct [:name, :filename, :description, :properties, :schema]
 
   alias GoogleApi.Discovery.V1.Model.JsonSchema
   alias GoogleApis.Generator.ElixirGenerator.{Property, ResourceContext}

--- a/lib/google_apis/generator/elixir_generator/token.ex
+++ b/lib/google_apis/generator/elixir_generator/token.ex
@@ -18,7 +18,7 @@ defmodule GoogleApis.Generator.ElixirGenerator.Token do
   """
 
   alias GoogleApi.Discovery.V1.Model.RestDescription
-  alias GoogleApis.Generator.ElixirGenerator.{Model, Parameter, ResourceContext}
+  alias GoogleApis.Generator.ElixirGenerator.{Model, Api, Parameter, ResourceContext}
   alias GoogleApis.ApiConfig
 
   @type t :: %__MODULE__{
@@ -33,6 +33,7 @@ defmodule GoogleApis.Generator.ElixirGenerator.Token do
           :resource_context => ResourceContext.t(),
           :models => list(Model.t()),
           :models_by_name => %{String.t() => Model.t()},
+          :apis => list(Api.t()),
           :global_optional_parameters => list(Parameter.t()),
           :data_wrapped => boolean()
         }
@@ -49,6 +50,7 @@ defmodule GoogleApis.Generator.ElixirGenerator.Token do
     :resource_context,
     :models,
     :models_by_name,
+    :apis,
     :global_optional_parameters,
     :data_wrapped
   ]


### PR DESCRIPTION
Fixes #2435 

The compute API has several models that map to the same file name: `HttpHealthCheck` and `HTTPHealthCheck` both generate as `http_health_check.ex`. So in the generator, one would overwrite the other, and so one would be missing from the final generated library. Same with `HttpsHealthCheck` and `HTTPSHealthCheck`.

This PR does an analysis looking for duplicated filenames (in models and apis), and dedups them by adding `_1`, `_2` etc. to the filename if it already exists. It also sorts the inputs to ensure that input ordering doesn't change which module gets assigned which filename.