### PR TITLE
fix: handle resource names with hyphens

### DIFF
--- a/lib/google_apis/generator/elixir_generator.ex
+++ b/lib/google_apis/generator/elixir_generator.ex
@@ -276,7 +276,7 @@ defmodule GoogleApis.Generator.ElixirGenerator do
   def all_apis(%{resources: resources}, context) do
     resources
     |> Enum.map(fn {name, resource} ->
-      name = Macro.camelize(name)
+      name = name |> String.replace("-", "_") |> Macro.camelize()
       methods = collect_methods(resource)
 
       %Api{

--- a/lib/google_apis/generator/elixir_generator/endpoint.ex
+++ b/lib/google_apis/generator/elixir_generator/endpoint.ex
@@ -257,7 +257,7 @@ defmodule GoogleApis.Generator.ElixirGenerator.Endpoint do
 
   defp method_name_to_endpoint_name(method_name) do
     method_name
-    |> String.replace(".", "_")
+    |> String.replace(~r{[\.-]}, "_")
     |> Macro.underscore()
   end
 end


### PR DESCRIPTION
Fixes #2436 

Some resource names have hyphens, which is currently messing with codegen since an Elixir function name cannot (easily) include hyphens. This currently affects the GKE API.

This PR replaces hyphens with underscores when generating function names.