### PR TITLE
fix: handle resource types without any properties

### DIFF
--- a/lib/google_apis/generator/elixir_generator/model.ex
+++ b/lib/google_apis/generator/elixir_generator/model.ex
@@ -81,6 +81,17 @@ defmodule GoogleApis.Generator.ElixirGenerator.Model do
     [model | property_models]
   end
 
+  defp from_schema(name, schema = %JsonSchema{type: "object", id: name}, context) do
+    model = %__MODULE__{
+      name: ResourceContext.name(context, name),
+      description: schema.description,
+      properties: [],
+      schema: %JsonSchema{schema | properties: []}
+    }
+
+    [model]
+  end
+
   defp from_schema(name, %JsonSchema{type: "array", items: items}, context) do
     from_schema(name, items, context)
   end


### PR DESCRIPTION
Fixes #2438 

IdentityToolkit is failing to generate properly because the `IdentitytoolkitRelyingpartyGetPublicKeysResponse` resource in the discovery doc has no `properties` field. This may technically be an error in the discovery doc, but we can work around it by generating the model if the resource has an ID even if it is missing properties (by assuming the property list is empty).