### PR TITLE
fix: api response typespecs reflect the option to skip decoding

### DIFF
--- a/lib/google_apis/generator/elixir_generator/endpoint.ex
+++ b/lib/google_apis/generator/elixir_generator/endpoint.ex
@@ -246,7 +246,7 @@ defmodule GoogleApis.Generator.ElixirGenerator.Endpoint do
         _ -> ", " <> param_specs
       end
 
-    "#{name}(Tesla.Env.client()#{param_specs}, keyword(), keyword()) :: {:ok, #{ret.typespec}} | {:error, Tesla.Env.t()}"
+    "#{name}(Tesla.Env.client()#{param_specs}, keyword(), keyword()) :: {:ok, #{ret.typespec}} | {:ok, Tesla.Env.t()} | {:error, Tesla.Env.t()}"
   end
 
   defp return_type(%{response: nil}, _context), do: Type.empty()

--- a/test/google_apis/generator/elixir_generator/endpoint_test.exs
+++ b/test/google_apis/generator/elixir_generator/endpoint_test.exs
@@ -177,7 +177,7 @@ defmodule GoogleApis.Generator.ElixirGenerator.EndpointTest do
     assert 1 == length(endpoints)
     endpoint = List.first(endpoints)
 
-    assert "books_familysharing_unshare(Tesla.Env.client(), String.t, integer(), keyword(), keyword()) :: {:ok, Default.Namespace.Model.Annotationsdata.t} | {:error, Tesla.Env.t()}" ==
+    assert "books_familysharing_unshare(Tesla.Env.client(), String.t, integer(), keyword(), keyword()) :: {:ok, Default.Namespace.Model.Annotationsdata.t} | {:ok, Tesla.Env.t()} | {:error, Tesla.Env.t()}" ==
              endpoint.typespec
   end
 
@@ -189,7 +189,7 @@ defmodule GoogleApis.Generator.ElixirGenerator.EndpointTest do
     assert 1 == length(endpoints)
     endpoint = List.first(endpoints)
 
-    assert "books_familysharing_unshare(Tesla.Env.client(), keyword(), keyword()) :: {:ok, nil} | {:error, Tesla.Env.t()}" ==
+    assert "books_familysharing_unshare(Tesla.Env.client(), keyword(), keyword()) :: {:ok, nil} | {:ok, Tesla.Env.t()} | {:error, Tesla.Env.t()}" ==
              endpoint.typespec
   end
 
@@ -201,7 +201,7 @@ defmodule GoogleApis.Generator.ElixirGenerator.EndpointTest do
     assert 1 == length(endpoints)
     endpoint = List.first(endpoints)
 
-    assert "books_myconfig_release_download_access(Tesla.Env.client(), list(String.t), String.t, keyword(), keyword()) :: {:ok, Default.Namespace.Model.DownloadAccesses.t} | {:error, Tesla.Env.t()}" ==
+    assert "books_myconfig_release_download_access(Tesla.Env.client(), list(String.t), String.t, keyword(), keyword()) :: {:ok, Default.Namespace.Model.DownloadAccesses.t} | {:ok, Tesla.Env.t()} | {:error, Tesla.Env.t()}" ==
              endpoint.typespec
   end
 


### PR DESCRIPTION
If you skip decoding, API calls can return `{:ok, Tesla.Env.t()}`. Make sure this is part of the generated typespec. Fixes #2624 
