### PR TITLE
fix: handle responses with compressed content-encoding

### DIFF
--- a/clients/gax/README.md
+++ b/clients/gax/README.md
@@ -10,7 +10,7 @@ by adding `google_gax` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:google_gax, "~> 0.3.1"}
+    {:google_gax, "~> 0.3.2"}
   ]
 end
 ```

--- a/clients/gax/lib/google_api/gax/connection.ex
+++ b/clients/gax/lib/google_api/gax/connection.ex
@@ -33,6 +33,8 @@ defmodule GoogleApi.Gax.Connection do
         )
       )
 
+      plug(Tesla.Middleware.DecompressResponse, [])
+
       plug(Tesla.Middleware.EncodeJson, engine: Poison)
 
       @doc """

--- a/clients/gax/mix.exs
+++ b/clients/gax/mix.exs
@@ -1,7 +1,7 @@
 defmodule GoogleApi.Gax.MixProject do
   use Mix.Project
 
-  @version "0.3.1"
+  @version "0.3.2"
 
   def project do
     [


### PR DESCRIPTION
It looks like some APIs (notably discovery) are starting to return responses with `content-encoding: gzip`. We need to handle this case.