### PR TITLE
fix: hack docs link for admin

### DIFF
--- a/lib/google_apis/generator/elixir_generator.ex
+++ b/lib/google_apis/generator/elixir_generator.ex
@@ -237,6 +237,7 @@ defmodule GoogleApis.Generator.ElixirGenerator do
 
   defp api_title_for(%{title: title}) when is_binary(title), do: title
 
+  defp docs_link_for(%{documentationLink: "/admin-sdk/" <> _ = link}), do: "https://developers.google.com#{link}"
   defp docs_link_for(%{documentationLink: link}) when is_binary(link), do: link
   defp docs_link_for(_), do: "https://cloud.google.com/"
 


### PR DESCRIPTION
This is a hack for the admin library, which currently has a malformed documentation link (i.e. a relative rather than absolute URL) and thus has not been able to release to hex.