### PR TITLE
fix: decompress discovery docs on download

### DIFF
--- a/lib/google_apis/discovery.ex
+++ b/lib/google_apis/discovery.ex
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 defmodule GoogleApis.Discovery do
+  defmodule Client do
+    use Tesla
+    plug(Tesla.Middleware.DecompressResponse, [])
+  end
+
   alias GoogleApis.ApiConfig
   alias GoogleApi.Discovery.V1.Connection
   alias GoogleApi.Discovery.V1.Api.Apis
@@ -116,7 +121,7 @@ defmodule GoogleApis.Discovery do
   defp fetch_direct(url) do
     Logger.info("FETCHING: #{url}")
 
-    with {:ok, %Tesla.Env{status: 200, body: body}} <- Tesla.get(url) do
+    with {:ok, %Tesla.Env{status: 200, body: body}} <- Client.get(url) do
       Logger.info("FOUND: #{url}")
       {:ok, body}
     else


### PR DESCRIPTION
It turns out that #4065 did not actually fix the synth of Tasks and Blogger because the code that downloads the discovery doc doesn't use the discovery API. So I had to add the DecompressResponse middleware to the generator code that does that download.

Tested this against the actual responses for Tasks to verify that it does fix the issue.