### PR TITLE
Add {:error, :econnrefused} return spec to pull

### DIFF
--- a/clients/pub_sub/lib/google_api/pub_sub/v1/api/projects.ex
+++ b/clients/pub_sub/lib/google_api/pub_sub/v1/api/projects.ex
@@ -1451,6 +1451,7 @@ defmodule GoogleApi.PubSub.V1.Api.Projects do
           {:ok, GoogleApi.PubSub.V1.Model.PullResponse.t()}
           | {:ok, Tesla.Env.t()}
           | {:error, Tesla.Env.t()}
+          | {:error, :econnrefused}
   def pubsub_projects_subscriptions_pull(
         connection,
         projects_id,


### PR DESCRIPTION
Dialyzer is complaining when I use this function. Tesla returns a `{:error, :econnrefused}` tuple when the connection fails. This is not accounted for in the existing type spec.