### PR TITLE
fix: Allow regeneration based on generator changes

### DIFF
--- a/lib/google_apis/generator/elixir_generator.ex
+++ b/lib/google_apis/generator/elixir_generator.ex
@@ -66,7 +66,7 @@ defmodule GoogleApis.Generator.ElixirGenerator do
     with {:ok, old_metadata} <- File.read(path),
          [_, old_revision] <- Regex.run(~r/@discovery_revision "(\d{8})"/, old_metadata) do
       new_revision = token.rest_description.revision
-      result = Regex.match?(~r/^\d{8}$/, new_revision) && old_revision < new_revision
+      result = Regex.match?(~r/^\d{8}$/, new_revision) && old_revision <= new_revision
       IO.puts("Revision check: old=#{old_revision}, new=#{new_revision}, generating=#{result}")
       result
     else


### PR DESCRIPTION
I realized I missed the case where the discovery doc doesn't change but the generator does. So we still need to run generation if the discovery revision is _equal_ to the previous revision. We disable generation only if we got an _older_ discovery doc.