### PR TITLE
fix: Run synth in the current repo clone

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -19,19 +19,13 @@ from synthtool import _tracked_paths
 import synthtool as s
 import synthtool.log as log
 import synthtool.shell as shell
-import synthtool.sources.git as git
 import logging
 import os
-import shutil
-import sys
 
 logging.basicConfig(level=logging.DEBUG)
 s.metadata.set_track_obsolete_files(False)  # TODO: enable again.
 
-repository_url = "https://github.com/googleapis/elixir-google-api.git"
-
-log.debug(f"Cloning {repository_url}.")
-repository = git.clone(repository_url)
+repository = os.getcwd()
 
 image = "gcr.io/cloud-devrel-public-resources/elixir19"
 generate_command = "scripts/generate_client.sh"
@@ -52,9 +46,3 @@ if extra_args():
 log.debug(f"Running: {' '.join(command)}")
 
 shell.run(command, cwd=repository, hide_output=False)
-
-# clean destination before copying
-shutil.rmtree("clients", ignore_errors=True)
-
-# copy all clients
-s.copy(repository / "clients")


### PR DESCRIPTION
I think this should fix all the autosynth failures (e.g. #4985).

What seems to be happening is, when we moved autosynth into the synthtool code base, we merged the git logic. In particular, autosynth now uses synthtool's git class to do its cloning of the target repo (see https://github.com/googleapis/synthtool/blob/master/autosynth/synth.py#L518). This caused a problem for Elixir because Elixir's synth script does a second clone using the same class—thus cloning to the same directory. That is, the second clone clobbers the first, and the later logic gets confused because it wants to copy changes from one clone to the other.

This fix simply does away with the second clone, and performs modifications to the repo "in place". I do not believe the second clone is necessary any longer, assuming autosynth creates a fresh clone for every individual synth job in an autosynth-multi (which it must, or those jobs would affect one another). (@chingor13 Do you recall if there are other reasons we may still need a separate clone?)