### PR TITLE
feat: Roll back change if it's only a discovery revision

### DIFF
--- a/lib/google_apis.ex
+++ b/lib/google_apis.ex
@@ -52,4 +52,8 @@ defmodule GoogleApis do
   def bump_version(api_config) do
     GoogleApis.Generator.bump_version(api_config)
   end
+
+  def rollback_if_not_significant(api_configs) do
+    GoogleApis.Generator.rollback_if_not_significant(api_configs)
+  end
 end

--- a/lib/google_apis/change_analyzer.ex
+++ b/lib/google_apis/change_analyzer.ex
@@ -23,18 +23,45 @@ defmodule GoogleApis.ChangeAnalyzer do
 
   require Logger
 
+  @significance_levels %{
+    identical: 0,
+    discovery_revision: 1,
+    documentation: 2,
+    significant: 3
+  }
+
+  def has_changes_of_significance?(api_config, significance) do
+    actual_sig = compute_change_significance(api_config)
+    Map.fetch!(@significance_levels, actual_sig) >= Map.fetch!(@significance_levels, significance)
+  end
+
   @doc """
   Analyzes the git diff for the given API, and determines whether any of the
   changes are actual significant changes as opposed to documentation, comment,
   or formatting.
+
+  Returns one of the following:
+
+   *  `:identical` - The change includes at most changes to synth.metadata and
+      formatting/whitespace. We generally respond by not opening a synth PR.
+   *  `:discovery_revision` - The change includes at most a change to the
+      discovery revision (plus changes of lower significance) but no changes to
+      the code or documentation. We generally respond by not opening a synth PR.
+   *  `:documentation` - The change includes at most changes to the inline
+      documentation (plus changes of lower significance) but no changes to the
+      code. We generally respond by opening a PR and bumping the patch version.
+   *  `:significant` - The change includes code changes. We generally respond by
+      opening a PR and bumping the minor version.
   """
-  def has_significant_changes?(api_config) do
+  def compute_change_significance(api_config) do
     dir = ApiConfig.library_directory(api_config)
     {only_modified, files} = check_git_status(dir)
     if only_modified do
-      Enum.any?(files, &file_has_significant_changes?/1)
+      Enum.reduce(files, :identical, fn file, sig ->
+        file |> file_change_significance() |> combine_significance(sig)
+      end)
     else
-      true
+      :significant
     end
   end
 
@@ -65,80 +92,99 @@ defmodule GoogleApis.ChangeAnalyzer do
   end
 
   @elixir_source_extensions [".ex", ".exs"]
-  @non_significant_files ["synth.metadata", "README.md"]
+  @documentation_only_files ["README.md"]
+  @non_significant_files ["synth.metadata"]
 
-  defp file_has_significant_changes?(file) do
+  defp file_change_significance(file) do
     cond do
       Enum.member?(@elixir_source_extensions, Path.extname(file)) ->
-        elixir_file_has_significant_changes?(file)
+        elixir_file_change_significance(file)
+      Enum.member?(@documentation_only_files, Path.basename(file)) ->
+        :documentation
       Enum.member?(@non_significant_files, Path.basename(file)) ->
-        false
+        :identical
       true ->
-        true
+        :significant
     end
   end
 
-  defp elixir_file_has_significant_changes?(file) do
+  defp elixir_file_change_significance(file) do
     with {old_content, 0} <- System.cmd("git", ["show", "HEAD:#{file}"]),
          {:ok, new_content} <- File.read(file) do
-      elixir_content_has_significant_changes?(old_content, new_content, file)
+      elixir_content_change_significance(old_content, new_content, file)
     else
       {:error, _} ->
         Logger.error("Change analyzer: could not read file #{file}")
-        true
+        :significant
       _ ->
         Logger.error("Change analyzer: git show failed for file #{file}")
-        true
+        :significant
     end
   end
 
-  defp elixir_content_has_significant_changes?(old_content, new_content, file) do
+  defp elixir_content_change_significance(old_content, new_content, file) do
     with {:old, {:ok, old_ast}} <- {:old, Code.string_to_quoted(old_content)},
          {:new, {:ok, new_ast}} <- {:new, Code.string_to_quoted(new_content)} do
-      elixir_ast_has_significant_changes?(old_ast, new_ast, Path.basename(file))
+      elixir_ast_change_significance(old_ast, new_ast, Path.basename(file))
     else
       {:old, _} ->
         Logger.error("Change analyzer: parse of pre-change #{file} failed!")
-        true
+        :significant
       {:new, _} ->
         Logger.error("Change analyzer: parse of post-change #{file} failed!")
-        true
+        :significant
     end
   end
 
-  defp elixir_ast_has_significant_changes?(old_ast, new_ast, basename) do
-    strip_trivial_ast(old_ast, basename) != strip_trivial_ast(new_ast, basename)
+  defp elixir_ast_change_significance(old_ast, new_ast, basename) do
+    cond do
+      old_ast == new_ast ->
+        :identical
+      strip_trivial_ast(old_ast, :discovery_revision, basename) == strip_trivial_ast(new_ast, :discovery_revision, basename) ->
+        :discovery_revision
+      strip_trivial_ast(old_ast, :documentation, basename) == strip_trivial_ast(new_ast, :documentation, basename) ->
+        :documentation
+      true ->
+        :significant
+    end
   end
 
-  defp strip_trivial_ast({:@, _, [{:doc, _, [str]}]}, _) when is_binary(str) do
+  defp strip_trivial_ast({:@, _, [{:doc, _, [str]}]}, :documentation, _) when is_binary(str) do
     {:@, [], [{:doc, [], ["."]}]}
   end
 
-  defp strip_trivial_ast({:@, _, [{:moduledoc, _, [str]}]}, _) when is_binary(str) do
+  defp strip_trivial_ast({:@, _, [{:moduledoc, _, [str]}]}, _, _) when is_binary(str) do
     {:@, [], [{:moduledoc, [], ["."]}]}
   end
 
-  defp strip_trivial_ast({:@, _, [{:version, _, [str]}]}, "mix.exs") when is_binary(str) do
+  defp strip_trivial_ast({:@, _, [{:version, _, [str]}]}, _, "mix.exs") when is_binary(str) do
     {:@, [], [{:version, [], ["."]}]}
   end
 
-  defp strip_trivial_ast({:@, _, [{:discovery_revision, _, [str]}]}, "metadata.ex") when is_binary(str) do
+  defp strip_trivial_ast({:@, _, [{:discovery_revision, _, [str]}]}, sig_test, "metadata.ex")
+      when is_binary(str) and (sig_test == :documentation or sig_test == :discovery_revision) do
     {:@, [], [{:discovery_revision, [], ["."]}]}
   end
 
-  defp strip_trivial_ast({name, _, args}, basename) do
-    {strip_trivial_ast(name, basename), [], strip_trivial_ast(args, basename)}
+  defp strip_trivial_ast({name, _, args}, sig_test, basename) do
+    {strip_trivial_ast(name, sig_test, basename), [], strip_trivial_ast(args, sig_test, basename)}
   end
 
-  defp strip_trivial_ast(list, basename) when is_list(list) do
-    Enum.map(list, &(strip_trivial_ast(&1, basename)))
+  defp strip_trivial_ast(list, sig_test, basename) when is_list(list) do
+    Enum.map(list, &(strip_trivial_ast(&1, sig_test, basename)))
   end
 
-  defp strip_trivial_ast({key, value}, basename) do
-    {strip_trivial_ast(key, basename), strip_trivial_ast(value, basename)}
+  defp strip_trivial_ast({key, value}, sig_test, basename) do
+    {strip_trivial_ast(key, sig_test, basename), strip_trivial_ast(value, sig_test, basename)}
   end
 
-  defp strip_trivial_ast(term, _) do
+  defp strip_trivial_ast(term, _, _) do
     term
+  end
+
+  defp combine_significance(sig1, sig2) do
+    level1 = Map.fetch!(@significance_levels, sig1)
+    level2 = Map.fetch!(@significance_levels, sig2)
+    if level1 > level2, do: sig1, else: sig2
   end
 end

--- a/lib/mix/tasks/google_apis.generate.ex
+++ b/lib/mix/tasks/google_apis.generate.ex
@@ -33,5 +33,6 @@ defmodule Mix.Tasks.GoogleApis.Generate do
       GoogleApis.generate_client(api)
       GoogleApis.format_client(api)
     end)
+    GoogleApis.rollback_if_not_significant(apis)
   end
 end


### PR DESCRIPTION
After I made the change to store the discovery revision in the generated client (to ensure we don't regen a client from an earlier revision due to gradual discovery rollout), I ran into another issue. It is very common for new revisions of discovery documents to be released, with a change to the discovery revision (and also presumably the etag) but no other change. As a result, we're now getting dozens of PRs per day where the only change is that the discovery revision is updated. Example: https://github.com/googleapis/elixir-google-api/pull/5023/files

This change suppresses those PRs. At the end of generation, it runs an analysis of the change, and if the change includes only a discovery_revision bump and nothing else, it reverts the change and does not open a PR. Note that if multiple versions of an API are generated into the same library, it waits until all are generated before running the analysis, so it reverts the change only if _all_ API versions were at most discovery_revision bumps.

The implementation hinges on generalizing the ChangeAnalyzer so it can return one of several "levels" of change significance. Previously, it returned a boolean that distinguished only between "significant" and "non-significant". Now, "non-significant" is further separated into "documentation changed", "discovery revision changed", and "identical" (which means at most formatting/whitespace).