### PR TITLE
fix: Remove PageSpeedOnline v2 and v4 from the list

### DIFF
--- a/config/apis.json
+++ b/config/apis.json
@@ -655,16 +655,6 @@
     "name": "OSLogin"
   },
   {
-    "version": "v2",
-    "url": "https://www.googleapis.com/discovery/v1/apis/pagespeedonline/v2/rest",
-    "name": "PageSpeedOnline"
-  },
-  {
-    "version": "v4",
-    "url": "https://www.googleapis.com/discovery/v1/apis/pagespeedonline/v4/rest",
-    "name": "PageSpeedOnline"
-  },
-  {
     "version": "v5",
     "url": "https://www.googleapis.com/discovery/v1/apis/pagespeedonline/v5/rest",
     "name": "PageSpeedOnline"


### PR DESCRIPTION
V2 and V4 discovery docs are no more, but V5 is still present (see #5292)