### PR TITLE
feat(gax): Support decoding a list of lists

### DIFF
--- a/clients/gax/lib/google_api/gax/model_base.ex
+++ b/clients/gax/lib/google_api/gax/model_base.ex
@@ -71,13 +71,17 @@ defmodule GoogleApi.Gax.ModelBase do
   @doc """
   Helper to decode model fields
   """
-  @spec decode(struct(), :list | :map | :primitive, nil | module()) :: struct()
+  @spec decode(struct(), :list | :listlist | :map | :primitive, nil | module()) :: struct()
   def decode(nil, _, _) do
     nil
   end
 
   def decode(value, _, nil) do
     value
+  end
+
+  def decode(value, :listlist, module) do
+    Enum.map(value, &(decode(&1, :list, module)))
   end
 
   def decode(value, :list, DateTime) do

--- a/clients/gax/mix.exs
+++ b/clients/gax/mix.exs
@@ -1,7 +1,7 @@
 defmodule GoogleApi.Gax.MixProject do
   use Mix.Project
 
-  @version "0.3.3"
+  @version "0.4.0"
 
   def project do
     [

--- a/clients/gax/test/gax/api_test.exs
+++ b/clients/gax/test/gax/api_test.exs
@@ -20,7 +20,7 @@ defmodule Gax.ApiTest do
   @pets_json """
   {
     "pets": [
-      {"id": "pet1", "category": {"id": 1, "name": "Dogs"}, "name": "Fido", "tags": [], "status": "available"}
+      {"id": "pet1", "category": {"id": 1, "name": "Dogs"}, "name": "Fido", "tags": [{"id": 1, "name": "blue"}], "tagGroups": [[{"id": 2, "name": "green"}]], "status": "available"}
     ]
   }
   """
@@ -48,6 +48,8 @@ defmodule Gax.ApiTest do
 
     assert Enum.all?(pets.pets, fn pet ->
              assert %TestClient.Model.Pet{} = pet
+             assert [%TestClient.Model.Tag{}] = pet.tags
+             assert [[%TestClient.Model.Tag{}]] = pet.tagGroups
            end)
   end
 

--- a/clients/gax/test/test_client/model/pet.ex
+++ b/clients/gax/test/test_client/model/pet.ex
@@ -19,6 +19,7 @@ defmodule TestClient.Model.Pet do
   field(:category, as: TestClient.Model.Category)
   field(:name)
   field(:tags, as: TestClient.Model.Tag, type: :list)
+  field(:tagGroups, as: TestClient.Model.Tag, type: :listlist)
   field(:status)
 end
 


### PR DESCRIPTION
We've identified at least one case of a field being of type array of array of object (#3409) which is not supported by the gax ModelBase. This PR updates gax to support this case. A follow-up PR will update the generator to use this capability, once we release the gax update.