### PR TITLE
fix(generator): Correctly handle array-typed resources

### DIFF
--- a/clients/test_client/lib/google_api/test_client/v1/model/nested_container.ex
+++ b/clients/test_client/lib/google_api/test_client/v1/model/nested_container.ex
@@ -30,7 +30,7 @@ defmodule GoogleApi.TestClient.V1.Model.NestedContainer do
           :rows => list(list(GoogleApi.TestClient.V1.Model.NestedContainerRows.t()))
         }
 
-  field(:rows, type: :list)
+  field(:rows, as: GoogleApi.TestClient.V1.Model.NestedContainerRows, type: :listlist)
 end
 
 defimpl Poison.Decoder, for: GoogleApi.TestClient.V1.Model.NestedContainer do

--- a/clients/test_client/mix.exs
+++ b/clients/test_client/mix.exs
@@ -40,7 +40,7 @@ defmodule GoogleApi.TestClient.Mixfile do
 
   defp deps() do
     [
-      {:google_gax, "~> 0.2"},
+      {:google_gax, "~> 0.4"},
 
       {:ex_doc, "~> 0.16", only: :dev}
     ]

--- a/clients/test_client/test/type_test.exs
+++ b/clients/test_client/test/type_test.exs
@@ -20,7 +20,9 @@ defmodule Gax.TypeTest do
     ContainerObjectVal,
     DateContainer,
     GenericContainer,
-    NestedContainer
+    NestedContainer,
+    NestedContainerRows,
+    NestedContainerRowsNestedArrayValue
   }
 
   test "decodes strings" do
@@ -331,7 +333,12 @@ defmodule Gax.TypeTest do
     assert 2 == Enum.count(rows)
     assert Enum.all?(rows, fn row ->
       assert 2 == Enum.count(row)
-      # TODO: ensure this deeply nested struct is generated and decoded
+      assert Enum.all?(row, fn elem ->
+        assert %NestedContainerRows{nestedArrayValue: nested_array} = elem
+        assert Enum.all?(nested_array, fn nested_array_value ->
+          assert %NestedContainerRowsNestedArrayValue{} = nested_array_value
+        end)
+      end)
     end)
   end
 end

--- a/lib/google_apis/generator/elixir_generator.ex
+++ b/lib/google_apis/generator/elixir_generator.ex
@@ -124,10 +124,11 @@ defmodule GoogleApis.Generator.ElixirGenerator do
   end
 
   defp update_model_properties(token) do
+    context = ResourceContext.with_models_by_name(token.resource_context, token.models_by_name)
     Map.update!(token, :models, fn models ->
       models
       |> Enum.map(fn model ->
-        Model.update_properties(model, token.resource_context)
+        Model.update_properties(model, context)
       end)
     end)
   end

--- a/lib/google_apis/generator/elixir_generator/model.ex
+++ b/lib/google_apis/generator/elixir_generator/model.ex
@@ -22,10 +22,11 @@ defmodule GoogleApis.Generator.ElixirGenerator.Model do
           :filename => String.t(),
           :description => String.t(),
           :properties => list(Property.t()),
-          :schema => JsonSchema.t()
+          :schema => JsonSchema.t(),
+          :is_array => boolean()
         }
 
-  defstruct [:name, :filename, :description, :properties, :schema]
+  defstruct [:name, :filename, :description, :properties, :schema, :is_array]
 
   alias GoogleApi.Discovery.V1.Model.JsonSchema
   alias GoogleApis.Generator.ElixirGenerator.{Property, ResourceContext}
@@ -94,7 +95,10 @@ defmodule GoogleApis.Generator.ElixirGenerator.Model do
   end
 
   defp from_schema(name, %JsonSchema{type: "array", items: items}, context) do
-    from_schema(name, items, context)
+    case from_schema(name, items, context) do
+      [model | property_models] -> [%__MODULE__{model | is_array: true} | property_models]
+      [] -> []
+    end
   end
 
   defp from_schema(_, _, _), do: []

--- a/lib/google_apis/generator/elixir_generator/resource_context.ex
+++ b/lib/google_apis/generator/elixir_generator/resource_context.ex
@@ -16,10 +16,11 @@ defmodule GoogleApis.Generator.ElixirGenerator.ResourceContext do
   @type t :: %__MODULE__{
           :namespace => String.t(),
           :property => String.t(),
-          :base_path => String.t()
+          :base_path => String.t(),
+          :models_by_name => map()
         }
 
-  defstruct namespace: "Default Namespace", property: nil, base_path: ""
+  defstruct namespace: "Default Namespace", property: nil, base_path: "", models_by_name: %{}
 
   @doc """
   Return the default struct name for this context.
@@ -98,6 +99,13 @@ defmodule GoogleApis.Generator.ElixirGenerator.ResourceContext do
   """
   def with_base_path(context, base_path) do
     Map.put(context, :base_path, path(context, base_path))
+  end
+
+  @doc """
+  Returns a new ResourceContext with models by name map
+  """
+  def with_models_by_name(context, models_by_name) do
+    Map.put(context, :models_by_name, models_by_name)
   end
 
   @doc """

--- a/template/elixir/mix.exs.eex
+++ b/template/elixir/mix.exs.eex
@@ -40,7 +40,7 @@ defmodule <%= namespace %>.Mixfile do
 
   defp deps() do
     [
-      {:google_gax, "~> 0.2"},
+      {:google_gax, "~> 0.4"},
 
       {:ex_doc, "~> 0.16", only: :dev}
     ]

--- a/template/elixir/model.ex.eex
+++ b/template/elixir/model.ex.eex
@@ -32,7 +32,7 @@ defmodule <%= namespace %>.Model.<%= model.name %> do
     <% end %>
   }
   <%= for property <- model.properties do %>
-  field(:"<%= property.name %>"<%= if property.type.struct do %>, as: <%= property.type.struct %><% end %><%= if property.type.name == "array" do %>, type: :list<% end %><%= if property.type.name == "map" do %>, type: :map<% end %>)<% end %>
+  field(:"<%= property.name %>"<%= if property.type.struct do %>, as: <%= property.type.struct %><% end %><%= if property.type.name == "array" do %>, type: :list<% end %><%= if property.type.name == "arrayarray" do %>, type: :listlist<% end %><%= if property.type.name == "map" do %>, type: :map<% end %>)<% end %>
 end
 
 defimpl Poison.Decoder, for: <%= namespace %>.Model.<%= model.name %> do

--- a/test/google_apis/generator/elixir_generator/model_test.exs
+++ b/test/google_apis/generator/elixir_generator/model_test.exs
@@ -285,6 +285,41 @@ defmodule GoogleApis.Generator.ElixirGenerator.ModelTest do
   }
   """
 
+  @array_resource_schema """
+  {
+    "id": "ArrayResource",
+    "type": "array",
+    "description": "Resource of array type",
+    "items": {
+      "type": "object",
+      "description": "An item in an ArrayResource",
+      "properties": {
+        "field1": {
+          "type": "string",
+          "description": "String value in an ArrayResource item"
+        }
+      }
+    }
+  }
+  """
+
+  @array_resource_referencer_schema """
+  {
+    "id": "ArrayResourceReferencer",
+    "type": "object",
+    "description": "Schema that references an ArrayResource",
+    "properties": {
+      "references": {
+        "type": "array",
+        "description": "Array of references to ArrayResource",
+        "items": {
+          "$ref": "ArrayResource"
+        }
+      }
+    }
+  }
+  """
+
   test "loads nested schemas" do
     schema = Poison.decode!(@test_schema, as: %JsonSchema{})
 
@@ -321,6 +356,16 @@ defmodule GoogleApis.Generator.ElixirGenerator.ModelTest do
     assert 3 == length(models)
 
     assert ["Volume", "VolumeAccessInfo", "VolumeAccessInfoEpub"] == Enum.map(models, & &1.name)
+  end
+
+  test "loads array resource schemas" do
+    array_resource_schema = Poison.decode!(@array_resource_schema, as: %JsonSchema{})
+    referencer_schema = Poison.decode!(@array_resource_referencer_schema, as: %JsonSchema{})
+    models = Model.from_schemas(%{"ArrayResource" => array_resource_schema, "Referencer" => referencer_schema})
+
+    assert [array_resource_model, referencer_model] = models
+    assert array_resource_model.is_array == true
+    assert referencer_model.is_array == nil
   end
 
   test "loads map types" do
@@ -405,7 +450,8 @@ defmodule GoogleApis.Generator.ElixirGenerator.ModelTest do
     assert 1 == length(model.properties)
     property = List.first(model.properties)
 
-    assert nil == property.type.struct
+    assert "My.Namespace.Model.NestedContainerRows" == property.type.struct
+    assert "arrayarray" == property.type.name
     assert "list(list(My.Namespace.Model.NestedContainerRows.t))" == property.type.typespec
   end
 end


### PR DESCRIPTION
This PR depends on #5686, and, in combination with that one, is meant to address #3409. The issue is that a _resource_ has an array type rather than an object type. (There seems to be only one case of this that I've found in our current set of discovery documents.) As a result, when a field references that resource, it needs to know to wrap the type in an extra list.

The solution is in two parts:
1. Support a "list of lists" type to handle nested arrays properly. #5686 adds this type (`:listlist`) to the gax ModelBase and provides the code necessary to deserialize it. Then, this PR adds the model type `"arrayarray"` and responds by generating a `:listlist` field. Together, these will catch nested array specifications in the discovery doc and generate the correct types.
2. Handle the special case of a resource itself having an array type. We can't map this kind of model directly to Elixir, because Elixir structs are not arrays/lists. So instead, we add a flag `:is_array` to the Model representation. Then, when a model is referenced by a field, we look up the model and see if the flag is set. If so, we wrap the _field's_ type in another layer of list.

Together, these should solve #3409, and they also allow us to complete the NestedContainer test in the test client.

Note: This PR will not pass CI until #5686 is merged and version 0.4.0 of google_gax is released.