### PR TITLE
fix(generator): Skip response decoding by default on download methods when alt=media is set

### DIFF
--- a/lib/google_apis/generator/elixir_generator/endpoint.ex
+++ b/lib/google_apis/generator/elixir_generator/endpoint.ex
@@ -31,6 +31,7 @@ defmodule GoogleApis.Generator.ElixirGenerator.Endpoint do
           :typespec => String.t(),
           :return => Type.t(),
           :method => String.t(),
+          :is_download => boolean(),
           :path => String.t()
         }
 
@@ -43,6 +44,7 @@ defmodule GoogleApis.Generator.ElixirGenerator.Endpoint do
     :typespec,
     :return,
     :method,
+    :is_download,
     :path
   ]
 
@@ -81,6 +83,7 @@ defmodule GoogleApis.Generator.ElixirGenerator.Endpoint do
       optional_parameters: optional_parameters,
       path_parameters: Enum.filter(required_parameters, fn p -> p.location == "path" end),
       typespec: typespec(name, required_parameters, ret),
+      is_download: method.supportsMediaDownload,
       return: ret
     } | endpoints]
   end

--- a/template/elixir/api.ex.eex
+++ b/template/elixir/api.ex.eex
@@ -44,6 +44,9 @@ defmodule <%= namespace %>.Api.<%= api.name %> do
   """
   @spec <%= endpoint.typespec %>
   def <%= endpoint.name %>(connection, <%= for parameter <- endpoint.required_parameters do %><%= parameter.variable_name %>, <% end %>optional_params \\ [], opts \\ []) do
+    <%= if endpoint.is_download do %>
+    opts = if Keyword.get(optional_params, :alt) == "media", do: Keyword.put_new(opts, :decode, false), else: opts
+    <% end %>
     optional_params_config = %{
     <%= for parameter <- global_optional_parameters do %>
       :"<%= parameter.name%>" => :"<%= parameter.location %>",


### PR DESCRIPTION
If a method sets `supportsMediaDownload`, add special behavior in the generated code where if `alt: "media"` is set, we also set the `decode: false` option by default. This addresses the standard media download behavior that downloads raw content if the `alt=media` query parameter is used. See #3573.
