### PR TITLE
fix(generator): Don't throw away changes that affect only moduledoc

### DIFF
--- a/lib/google_apis/change_analyzer.ex
+++ b/lib/google_apis/change_analyzer.ex
@@ -153,7 +153,7 @@ defmodule GoogleApis.ChangeAnalyzer do
     {:@, [], [{:doc, [], ["."]}]}
   end
 
-  defp strip_trivial_ast({:@, _, [{:moduledoc, _, [str]}]}, _, _) when is_binary(str) do
+  defp strip_trivial_ast({:@, _, [{:moduledoc, _, [str]}]}, :documentation, _) when is_binary(str) do
     {:@, [], [{:moduledoc, [], ["."]}]}
   end
 


### PR DESCRIPTION
I noticed that changes that affect only `@moduledoc` annotations were not getting through. This is because the ChangeAnalyzer is trying to recognize changes that involve only an update to the discovery revision and nothing else, and is treating those as no-op changes and preventing them from opening PRs. Except the ChangeAnalyzer had a bug where a `@moduledoc` change was incorrectly classified as not being a documentation change. (More specifically, when the ChangeAnalyzer checked whether a change was "discovery-revision-only", it incorrectly ignored `@moduledoc` changes.) This PR fixes the logic so `@moduledoc` changes are ignored only when distinguishing "documentation-only" from "significant change".