### PR TITLE
fix(generator): Base URL path should be empty if any method path is absolute

### DIFF
--- a/lib/google_apis/generator/elixir_generator/resource_context.ex
+++ b/lib/google_apis/generator/elixir_generator/resource_context.ex
@@ -119,6 +119,8 @@ defmodule GoogleApis.Generator.ElixirGenerator.ResourceContext do
   @doc """
   Return a full endpoint path given the provided context
   """
+  def path(_, "/" <> path_suffix), do: path_suffix
+
   def path(%{base_path: nil}, path_suffix), do: path_suffix
 
   def path(%{base_path: base_path}, path_suffix), do: Path.join([base_path, path_suffix])

--- a/lib/google_apis/generator/elixir_generator/token.ex
+++ b/lib/google_apis/generator/elixir_generator/token.ex
@@ -103,26 +103,27 @@ defmodule GoogleApis.Generator.ElixirGenerator.Token do
   end
 
   defp determine_base_paths(rest_description) do
-    if supports_media_upload?(rest_description.resources) do
+    if any_resource_has_absolute_paths?(rest_description.resources) do
       {rest_description.rootUrl, rest_description.servicePath}
     else
-      {rest_description.baseUrl, ""}
+      {URI.merge(rest_description.rootUrl, rest_description.servicePath), ""}
     end
   end
 
-  defp supports_media_upload?(nil), do: false
+  defp any_resource_has_absolute_paths?(nil), do: false
 
-  defp supports_media_upload?(resources) do
+  defp any_resource_has_absolute_paths?(resources) do
     Enum.any?(resources, fn {_name, resource} ->
-      supports_media_upload?(resource.resources) || has_media_upload_method?(resource.methods)
+      any_resource_has_absolute_paths?(resource.resources) || any_method_has_absolute_paths?(resource.methods)
     end)
   end
 
-  defp has_media_upload_method?(nil), do: false
+  defp any_method_has_absolute_paths?(nil), do: false
 
-  defp has_media_upload_method?(methods) do
-    Enum.any?(methods, fn {_name, method} ->
-      method.supportsMediaUpload
+  defp any_method_has_absolute_paths?(methods) do
+    Enum.any?(methods, fn
+      {_name, %{path: "/" <> _}} -> true
+      {_name, method} -> method.supportsMediaUpload
     end)
   end
 

--- a/test/google_apis/generator/elixir_generator/resource_context_test.exs
+++ b/test/google_apis/generator/elixir_generator/resource_context_test.exs
@@ -60,6 +60,6 @@ defmodule GoogleApis.Generator.ElixirGenerator.ResourceContextTest do
       |> ResourceContext.with_base_path("/v1/storage")
 
     assert "v1/storage/foo/bar" == ResourceContext.path(context, "foo/bar")
-    assert "v1/storage/foo/bar" == ResourceContext.path(context, "/foo/bar")
+    assert "foo/bar" == ResourceContext.path(context, "/foo/bar")
   end
 end


### PR DESCRIPTION
Currently, we prefer that the baseUrl include the service path for most cases. However, if a service includes any media upload, those paths are specified as absolute (i.e. do not respect the service path) and therefore the baseUrl cannot include the service path. So those cases use a baseUrl with an empty path, and prepend the service path to the method path.

It turns out there are a few other cases where a method path is specified as absolute (see #4477). So we expand the logic to check for _any_ absolute method paths in addition to the presence of media upload. We also update the ResourceContext path concatenation logic to respect absolute paths. This should fix #4477 after regeneration.