### PR TITLE
fix(generator): Ensure homepage link is not empty

### DIFF
--- a/lib/google_apis/generator/elixir_generator.ex
+++ b/lib/google_apis/generator/elixir_generator.ex
@@ -271,6 +271,7 @@ defmodule GoogleApis.Generator.ElixirGenerator do
   defp api_title_for(%{title: title}) when is_binary(title), do: title
 
   defp docs_link_for(%{documentationLink: "/admin-sdk/" <> _ = link}), do: "https://developers.google.com#{link}"
+  defp docs_link_for(%{documentationLink: ""}), do: "https://cloud.google.com/"
   defp docs_link_for(%{documentationLink: link}) when is_binary(link), do: link
   defp docs_link_for(_), do: "https://cloud.google.com/"
 


### PR DESCRIPTION
Tasks library is failing to publish because the Homepage link is the empty string. This is because the documentationLink in the discovery doc is the empty string. Handle this case in the generator: use a default link if documentationLink is empty.