### PR TITLE
fix(generator): Change analyzer classifies description changes as documentation-only

### DIFF
--- a/lib/google_apis/change_analyzer.ex
+++ b/lib/google_apis/change_analyzer.ex
@@ -157,6 +157,10 @@ defmodule GoogleApis.ChangeAnalyzer do
     {:@, [], [{:moduledoc, [], ["."]}]}
   end
 
+  defp strip_trivial_ast({:defp, _, [{:description, _, []}, [do: str]]}, :documentation, "mix.exs") when is_binary(str) do
+    {:defp, [], [{:description, [], []}, [do: "."]]}
+  end
+
   defp strip_trivial_ast({:@, _, [{:version, _, [str]}]}, _, "mix.exs") when is_binary(str) do
     {:@, [], [{:version, [], ["."]}]}
   end


### PR DESCRIPTION
I've seen a few cases where documentation-only changes are being classified as significant changes because they affect the description in `mix.exs`. This modifies the change analyzer so that if that particular function looks as we expect, then changes to it are treated as documentation-only.