### PR TITLE
chore: Implement full presubmit checks in GH actions

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,0 +1,30 @@
+name: Presubmit
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  presubmit:
+    strategy:
+      matrix:
+        include:
+          - elixir: "1.6.6"
+            otp: "21.3.8.17"
+          - elixir: "1.9.4"
+            otp: "22.3.4.5"
+          - elixir: "1.10.4"
+            otp: "23.0.3"
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Install Elixir ${{matrix.elixir}} on OTP ${{matrix.otp}}
+        uses: actions/setup-elixir@v1
+        with:
+          otp-version: ${{matrix.otp}}
+          elixir-version: ${{matrix.elixir}}
+      - name: Run presubmits
+        run: mix do deps.get, presubmit

--- a/lib/mix/tasks/presubmit.ex
+++ b/lib/mix/tasks/presubmit.ex
@@ -1,0 +1,77 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Mix.Tasks.Presubmit do
+  use Mix.Task
+
+  @shortdoc "Presubmit tests"
+
+  def run(_) do
+    cmd_opts = [into: IO.stream(:stdio, :line), env: [{"MIX_ENV", "test"}]]
+    {generator_changed, changed_clients} = get_changes()
+    if generator_changed do
+      header("Running tests for generator")
+      {_, 0} = System.cmd("mix", ["test", "--include=external"], cmd_opts)
+      header("Building test client")
+      {_, 0} = System.cmd("mix", ["google_apis.build", "TestClient"], into: IO.stream(:stdio, :line))
+      header("Running tests for test client")
+      {_, 0} = System.cmd("mix", ["do", "deps.get,", "test"], [{:cd, "clients/test_client"} | cmd_opts])
+    end
+    Enum.each(changed_clients, fn client ->
+      header("Running tests for client: #{client}")
+      {_, 0} = System.cmd("mix", ["do", "deps.get,", "test"], [{:cd, "clients/#{client}"} | cmd_opts])
+    end)
+  end
+
+  defp get_changes() do
+    base_ref = "GITHUB_EVENT_PATH" |> System.get_env() |> get_base_ref()
+    {output, 0} = System.cmd("git", ["--no-pager", "diff", "--name-only", base_ref])
+    files = String.split(output, "\n", trim: true)
+
+    changed_clients = files
+    |> Enum.reduce([], fn
+      ("clients/" <> path, list) ->
+        [name | _] = String.split(path, "/", parts: 2)
+        [name | list]
+      (_, list) -> list
+    end)
+    |> Enum.uniq()
+    |> Enum.sort()
+
+    generator_changed = Enum.any?(files, fn
+      ("mix." <> _) -> true
+      ("lib/" <> _) -> true
+      ("test/" <> _) -> true
+      ("template/" <> _) -> true
+      (_) -> false
+    end)
+
+    {generator_changed, changed_clients}
+  end
+
+  defp get_base_ref(nil), do: "HEAD"
+
+  defp get_base_ref(event_path) do
+    base_ref = event_path
+    |> File.read!()
+    |> Jason.decode!()
+    |> get_in(["pull_request", "base", "sha"])
+    {_, 0} = System.cmd("git", ["fetch", "--no-tags", "--prune", "--depth=1", "origin", base_ref], into: IO.stream(:stdio, :line))
+    base_ref
+  end
+
+  defp header(str) do
+    IO.puts("\n#{IO.ANSI.bright()}**** #{str} ****#{IO.ANSI.reset()}\n")
+  end
+end


### PR DESCRIPTION
I'm moving presubmit (and only presubmit for now) to GH actions. The main reason is better support for analysis of the PR and its diffs.

The GH actions version of the presubmit job has been enhanced to determine which clients have changed in the PR, and run `mix do deps.get, test` for those (and only those) clients. (Previously, only TestClient and Gax were actually tested.)

Once this is stable, I'll remove the kokoro presubmit. This is also a prerequisite for implementing autoapprove.