### PR TITLE
build: use yoshi approver for auto-approve

### DIFF
--- a/.github/workflows/autoapprove.yml
+++ b/.github/workflows/autoapprove.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
+    if: contains(github.head_ref, 'autosynth')
     env:
       ENABLE_AUTO_APPROVE: ${{ secrets.ENABLE_AUTO_APPROVE }}
     steps:

--- a/.github/workflows/autoapprove.yml
+++ b/.github/workflows/autoapprove.yml
@@ -16,7 +16,7 @@ jobs:
       - name: AutoApprove
         uses: actions/github-script@v2
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{secrets.YOSHI_APPROVER_TOKEN}}
           script: |
             if (context.payload.sender.login != "yoshi-automation") {
               core.error("AutoApprove: Not running for this sender.");


### PR DESCRIPTION
The `yoshi-approver` account has been added to `yoshi-elixir`, so it's approvals should grant CODEOWNERS so we can flip the "require codeowners" bit