### PR TITLE
Ensure Storage.object parameter encodes "/" chars (#6510)

### DIFF
--- a/clients/test_client/test/api_test.exs
+++ b/clients/test_client/test/api_test.exs
@@ -146,7 +146,7 @@ defmodule Gax.ApiTest do
   end
 
   test "url path encoding" do
-    mock(fn %{method: :delete, url: "http://localhost:8080/test/v1/b/bucket-1/o/some%2Fpath%2FFile%20with%20sp%C3%A4ces.zip"} ->
+    mock(fn %{method: :delete, url: "http://localhost:8080/test/v1/b/bucket-1/o/some/path/File%20with%20sp%C3%A4ces.zip"} ->
       %Tesla.Env{status: 200, body: @container_json}
     end)
 

--- a/clients/test_client/test/api_test.exs
+++ b/clients/test_client/test/api_test.exs
@@ -146,7 +146,7 @@ defmodule Gax.ApiTest do
   end
 
   test "url path encoding" do
-    mock(fn %{method: :delete, url: "http://localhost:8080/test/v1/b/bucket-1/o/some/path/File%20with%20sp%C3%A4ces.zip"} ->
+    mock(fn %{method: :delete, url: "http://localhost:8080/test/v1/b/bucket-1/o/some%2Fpath%2FFile%20with%20sp%C3%A4ces.zip"} ->
       %Tesla.Env{status: 200, body: @container_json}
     end)
 

--- a/lib/google_apis/generator/elixir_generator/parameter.ex
+++ b/lib/google_apis/generator/elixir_generator/parameter.ex
@@ -112,7 +112,7 @@ defmodule GoogleApis.Generator.ElixirGenerator.Parameter do
   @spec from_json_schema(String.t(), JsonSchema.t(), ResourceContext.t()) :: t
   def from_json_schema(name, schema, context, path \\ "")
 
-  def from_json_schema("object" = name, schema, context, _path) do
+  def from_json_schema("object" = name, schema, %ResourceContext{namespace: "GoogleApi.Storage.V1"} = context, _path) do
     %__MODULE__{
       name: name,
       variable_name: build_variable_name(name),


### PR DESCRIPTION
Add a simple exemption for the Storage `object` parameter to not treat it as a "path trailer" parameter.

Issue reported in #6510 

## Background

Changes released in v0.24 ([PR 5869](https://github.com/googleapis/elixir-google-api/pull/5869) for Issue #4600) allow a parameter,  if the last one in a path, to *not* URI.encode() the path separator (`/`).

However, the Storage API requires the `object` parameter to have path separator characters encoded, even though it is the last parameter in a URL path.
  
Since this seems to be the only API people have reported about, I've added a specific exception for the Storage `object` parameter to make sure it gets the full URI encoding.

Also closes #6352, which I believe is a duplicate of #6510.