### PR TITLE
fix: Loosen generated typespecs to support optional fields and streaming responses

### DIFF
--- a/lib/google_apis/generator/elixir_generator/endpoint.ex
+++ b/lib/google_apis/generator/elixir_generator/endpoint.ex
@@ -249,7 +249,7 @@ defmodule GoogleApis.Generator.ElixirGenerator.Endpoint do
         _ -> ", " <> param_specs
       end
 
-    "#{name}(Tesla.Env.client()#{param_specs}, keyword(), keyword()) :: {:ok, #{ret.typespec}} | {:ok, Tesla.Env.t()} | {:error, any()}"
+    "#{name}(Tesla.Env.client()#{param_specs}, keyword(), keyword()) :: {:ok, #{ret.typespec}} | {:ok, Tesla.Env.t()} | {:ok, list()} | {:error, any()}"
   end
 
   defp return_type(%{response: nil}, _context), do: Type.empty()

--- a/template/elixir/model.ex.eex
+++ b/template/elixir/model.ex.eex
@@ -28,7 +28,7 @@ defmodule <%= namespace %>.Model.<%= model.name %> do
 
   @type t :: %__MODULE__{
     <%= for property <- model.properties do %>
-      :"<%= property.name %>" => <%= property.type.typespec %>,
+      :"<%= property.name %>" => <%= property.type.typespec %> | nil,
     <% end %>
   }
   <%= for property <- model.properties do %>

--- a/test/google_apis/generator/elixir_generator/endpoint_test.exs
+++ b/test/google_apis/generator/elixir_generator/endpoint_test.exs
@@ -177,7 +177,7 @@ defmodule GoogleApis.Generator.ElixirGenerator.EndpointTest do
     assert 1 == length(endpoints)
     endpoint = List.first(endpoints)
 
-    assert "books_familysharing_unshare(Tesla.Env.client(), String.t, integer(), keyword(), keyword()) :: {:ok, Default.Namespace.Model.Annotationsdata.t} | {:ok, Tesla.Env.t()} | {:error, any()}" ==
+    assert "books_familysharing_unshare(Tesla.Env.client(), String.t, integer(), keyword(), keyword()) :: {:ok, Default.Namespace.Model.Annotationsdata.t} | {:ok, Tesla.Env.t()} | {:ok, list()} | {:error, any()}" ==
              endpoint.typespec
   end
 
@@ -189,7 +189,7 @@ defmodule GoogleApis.Generator.ElixirGenerator.EndpointTest do
     assert 1 == length(endpoints)
     endpoint = List.first(endpoints)
 
-    assert "books_familysharing_unshare(Tesla.Env.client(), keyword(), keyword()) :: {:ok, nil} | {:ok, Tesla.Env.t()} | {:error, any()}" ==
+    assert "books_familysharing_unshare(Tesla.Env.client(), keyword(), keyword()) :: {:ok, nil} | {:ok, Tesla.Env.t()} | {:ok, list()} | {:error, any()}" ==
              endpoint.typespec
   end
 
@@ -201,7 +201,7 @@ defmodule GoogleApis.Generator.ElixirGenerator.EndpointTest do
     assert 1 == length(endpoints)
     endpoint = List.first(endpoints)
 
-    assert "books_myconfig_release_download_access(Tesla.Env.client(), list(String.t), String.t, keyword(), keyword()) :: {:ok, Default.Namespace.Model.DownloadAccesses.t} | {:ok, Tesla.Env.t()} | {:error, any()}" ==
+    assert "books_myconfig_release_download_access(Tesla.Env.client(), list(String.t), String.t, keyword(), keyword()) :: {:ok, Default.Namespace.Model.DownloadAccesses.t} | {:ok, Tesla.Env.t()} | {:ok, list()} | {:error, any()}" ==
              endpoint.typespec
   end
 


### PR DESCRIPTION
Should address #6146 and #7273.
