### PR TITLE
Escape "/" in destinationObject for Objects.storage_objects_{copy,rew…

### DIFF
--- a/clients/storage/lib/google_api/storage/v1/api/objects.ex
+++ b/clients/storage/lib/google_api/storage/v1/api/objects.ex
@@ -195,8 +195,7 @@ defmodule GoogleApi.Storage.V1.Api.Objects do
           "sourceBucket" => URI.encode(source_bucket, &URI.char_unreserved?/1),
           "sourceObject" => URI.encode(source_object, &URI.char_unreserved?/1),
           "destinationBucket" => URI.encode(destination_bucket, &URI.char_unreserved?/1),
-          "destinationObject" =>
-            URI.encode(destination_object, &(URI.char_unreserved?(&1) || &1 == ?/))
+          "destinationObject" => URI.encode(destination_object, &URI.char_unreserved?/1)
         }
       )
       |> Request.add_optional_params(optional_params_config, optional_params)
@@ -1021,8 +1020,7 @@ defmodule GoogleApi.Storage.V1.Api.Objects do
           "sourceBucket" => URI.encode(source_bucket, &URI.char_unreserved?/1),
           "sourceObject" => URI.encode(source_object, &URI.char_unreserved?/1),
           "destinationBucket" => URI.encode(destination_bucket, &URI.char_unreserved?/1),
-          "destinationObject" =>
-            URI.encode(destination_object, &(URI.char_unreserved?(&1) || &1 == ?/))
+          "destinationObject" => URI.encode(destination_object, &URI.char_unreserved?/1)
         }
       )
       |> Request.add_optional_params(optional_params_config, optional_params)


### PR DESCRIPTION
…rite}

- otherwise, the storage API call would return "Not Found" error
- example:

  ```elixir
  %Tesla.Env{
    __client__: %Tesla.Client{...},
    __module__: GoogleApi.Storage.V1.Connection,
    body: "Not Found",
    headers: [...],
    method: :post,
    opts: [],
    query: [],
    status: 404,
    url: "https://storage.googleapis.com/storage/v1/b/bucket/o/from%2Fpath/copyTo/b/bucket/o/to/path"
  }}
  ```