### PR TITLE
Fix a Spec

### DIFF
--- a/clients/firestore/lib/google_api/firestore/v1/api/projects.ex
+++ b/clients/firestore/lib/google_api/firestore/v1/api/projects.ex
@@ -44,7 +44,7 @@ defmodule GoogleApi.Firestore.V1.Api.Projects do
       *   `:quotaUser` (*type:* `String.t`) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
       *   `:uploadType` (*type:* `String.t`) - Legacy upload protocol for media (e.g. "media", "multipart").
       *   `:upload_protocol` (*type:* `String.t`) - Upload protocol for media (e.g. "raw", "multipart").
-      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.GoogleFirestoreAdminV1ExportDocumentsRequest.t`) - 
+      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.GoogleFirestoreAdminV1ExportDocumentsRequest.t`) -
   *   `opts` (*type:* `keyword()`) - Call options
 
   ## Returns
@@ -118,7 +118,7 @@ defmodule GoogleApi.Firestore.V1.Api.Projects do
       *   `:quotaUser` (*type:* `String.t`) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
       *   `:uploadType` (*type:* `String.t`) - Legacy upload protocol for media (e.g. "media", "multipart").
       *   `:upload_protocol` (*type:* `String.t`) - Upload protocol for media (e.g. "raw", "multipart").
-      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.GoogleFirestoreAdminV1ImportDocumentsRequest.t`) - 
+      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.GoogleFirestoreAdminV1ImportDocumentsRequest.t`) -
   *   `opts` (*type:* `keyword()`) - Call options
 
   ## Returns
@@ -343,7 +343,7 @@ defmodule GoogleApi.Firestore.V1.Api.Projects do
       *   `:uploadType` (*type:* `String.t`) - Legacy upload protocol for media (e.g. "media", "multipart").
       *   `:upload_protocol` (*type:* `String.t`) - Upload protocol for media (e.g. "raw", "multipart").
       *   `:updateMask` (*type:* `String.t`) - A mask, relative to the field. If specified, only configuration specified by this field_mask will be updated in the field.
-      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.GoogleFirestoreAdminV1Field.t`) - 
+      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.GoogleFirestoreAdminV1Field.t`) -
   *   `opts` (*type:* `keyword()`) - Call options
 
   ## Returns
@@ -418,7 +418,7 @@ defmodule GoogleApi.Firestore.V1.Api.Projects do
       *   `:quotaUser` (*type:* `String.t`) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
       *   `:uploadType` (*type:* `String.t`) - Legacy upload protocol for media (e.g. "media", "multipart").
       *   `:upload_protocol` (*type:* `String.t`) - Upload protocol for media (e.g. "raw", "multipart").
-      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.GoogleFirestoreAdminV1Index.t`) - 
+      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.GoogleFirestoreAdminV1Index.t`) -
   *   `opts` (*type:* `keyword()`) - Call options
 
   ## Returns
@@ -712,7 +712,7 @@ defmodule GoogleApi.Firestore.V1.Api.Projects do
       *   `:quotaUser` (*type:* `String.t`) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
       *   `:uploadType` (*type:* `String.t`) - Legacy upload protocol for media (e.g. "media", "multipart").
       *   `:upload_protocol` (*type:* `String.t`) - Upload protocol for media (e.g. "raw", "multipart").
-      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.BatchGetDocumentsRequest.t`) - 
+      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.BatchGetDocumentsRequest.t`) -
   *   `opts` (*type:* `keyword()`) - Call options
 
   ## Returns
@@ -786,7 +786,7 @@ defmodule GoogleApi.Firestore.V1.Api.Projects do
       *   `:quotaUser` (*type:* `String.t`) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
       *   `:uploadType` (*type:* `String.t`) - Legacy upload protocol for media (e.g. "media", "multipart").
       *   `:upload_protocol` (*type:* `String.t`) - Upload protocol for media (e.g. "raw", "multipart").
-      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.BatchWriteRequest.t`) - 
+      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.BatchWriteRequest.t`) -
   *   `opts` (*type:* `keyword()`) - Call options
 
   ## Returns
@@ -858,7 +858,7 @@ defmodule GoogleApi.Firestore.V1.Api.Projects do
       *   `:quotaUser` (*type:* `String.t`) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
       *   `:uploadType` (*type:* `String.t`) - Legacy upload protocol for media (e.g. "media", "multipart").
       *   `:upload_protocol` (*type:* `String.t`) - Upload protocol for media (e.g. "raw", "multipart").
-      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.BeginTransactionRequest.t`) - 
+      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.BeginTransactionRequest.t`) -
   *   `opts` (*type:* `keyword()`) - Call options
 
   ## Returns
@@ -930,7 +930,7 @@ defmodule GoogleApi.Firestore.V1.Api.Projects do
       *   `:quotaUser` (*type:* `String.t`) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
       *   `:uploadType` (*type:* `String.t`) - Legacy upload protocol for media (e.g. "media", "multipart").
       *   `:upload_protocol` (*type:* `String.t`) - Upload protocol for media (e.g. "raw", "multipart").
-      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.CommitRequest.t`) - 
+      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.CommitRequest.t`) -
   *   `opts` (*type:* `keyword()`) - Call options
 
   ## Returns
@@ -1005,7 +1005,7 @@ defmodule GoogleApi.Firestore.V1.Api.Projects do
       *   `:upload_protocol` (*type:* `String.t`) - Upload protocol for media (e.g. "raw", "multipart").
       *   `:documentId` (*type:* `String.t`) - The client-assigned document ID to use for this document. Optional. If not specified, an ID will be assigned by the service.
       *   `:"mask.fieldPaths"` (*type:* `list(String.t)`) - The list of field paths in the mask. See Document.fields for a field path syntax reference.
-      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.Document.t`) - 
+      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.Document.t`) -
   *   `opts` (*type:* `keyword()`) - Call options
 
   ## Returns
@@ -1320,7 +1320,7 @@ defmodule GoogleApi.Firestore.V1.Api.Projects do
       *   `:quotaUser` (*type:* `String.t`) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
       *   `:uploadType` (*type:* `String.t`) - Legacy upload protocol for media (e.g. "media", "multipart").
       *   `:upload_protocol` (*type:* `String.t`) - Upload protocol for media (e.g. "raw", "multipart").
-      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.ListCollectionIdsRequest.t`) - 
+      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.ListCollectionIdsRequest.t`) -
   *   `opts` (*type:* `keyword()`) - Call options
 
   ## Returns
@@ -1394,7 +1394,7 @@ defmodule GoogleApi.Firestore.V1.Api.Projects do
       *   `:quotaUser` (*type:* `String.t`) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
       *   `:uploadType` (*type:* `String.t`) - Legacy upload protocol for media (e.g. "media", "multipart").
       *   `:upload_protocol` (*type:* `String.t`) - Upload protocol for media (e.g. "raw", "multipart").
-      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.ListenRequest.t`) - 
+      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.ListenRequest.t`) -
   *   `opts` (*type:* `keyword()`) - Call options
 
   ## Returns
@@ -1466,7 +1466,7 @@ defmodule GoogleApi.Firestore.V1.Api.Projects do
       *   `:quotaUser` (*type:* `String.t`) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
       *   `:uploadType` (*type:* `String.t`) - Legacy upload protocol for media (e.g. "media", "multipart").
       *   `:upload_protocol` (*type:* `String.t`) - Upload protocol for media (e.g. "raw", "multipart").
-      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.PartitionQueryRequest.t`) - 
+      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.PartitionQueryRequest.t`) -
   *   `opts` (*type:* `keyword()`) - Call options
 
   ## Returns
@@ -1542,7 +1542,7 @@ defmodule GoogleApi.Firestore.V1.Api.Projects do
       *   `:"currentDocument.updateTime"` (*type:* `DateTime.t`) - When set, the target document must exist and have been last updated at that time.
       *   `:"mask.fieldPaths"` (*type:* `list(String.t)`) - The list of field paths in the mask. See Document.fields for a field path syntax reference.
       *   `:"updateMask.fieldPaths"` (*type:* `list(String.t)`) - The list of field paths in the mask. See Document.fields for a field path syntax reference.
-      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.Document.t`) - 
+      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.Document.t`) -
   *   `opts` (*type:* `keyword()`) - Call options
 
   ## Returns
@@ -1618,7 +1618,7 @@ defmodule GoogleApi.Firestore.V1.Api.Projects do
       *   `:quotaUser` (*type:* `String.t`) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
       *   `:uploadType` (*type:* `String.t`) - Legacy upload protocol for media (e.g. "media", "multipart").
       *   `:upload_protocol` (*type:* `String.t`) - Upload protocol for media (e.g. "raw", "multipart").
-      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.RollbackRequest.t`) - 
+      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.RollbackRequest.t`) -
   *   `opts` (*type:* `keyword()`) - Call options
 
   ## Returns
@@ -1690,7 +1690,7 @@ defmodule GoogleApi.Firestore.V1.Api.Projects do
       *   `:quotaUser` (*type:* `String.t`) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
       *   `:uploadType` (*type:* `String.t`) - Legacy upload protocol for media (e.g. "media", "multipart").
       *   `:upload_protocol` (*type:* `String.t`) - Upload protocol for media (e.g. "raw", "multipart").
-      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.RunQueryRequest.t`) - 
+      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.RunQueryRequest.t`) -
   *   `opts` (*type:* `keyword()`) - Call options
 
   ## Returns
@@ -1705,6 +1705,7 @@ defmodule GoogleApi.Firestore.V1.Api.Projects do
           keyword()
         ) ::
           {:ok, GoogleApi.Firestore.V1.Model.RunQueryResponse.t()}
+          | {:ok, [GoogleApi.Firestore.V1.Model.RunQueryResponse.t()]}
           | {:ok, Tesla.Env.t()}
           | {:ok, list()}
           | {:error, any()}
@@ -1762,7 +1763,7 @@ defmodule GoogleApi.Firestore.V1.Api.Projects do
       *   `:quotaUser` (*type:* `String.t`) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
       *   `:uploadType` (*type:* `String.t`) - Legacy upload protocol for media (e.g. "media", "multipart").
       *   `:upload_protocol` (*type:* `String.t`) - Upload protocol for media (e.g. "raw", "multipart").
-      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.WriteRequest.t`) - 
+      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.WriteRequest.t`) -
   *   `opts` (*type:* `keyword()`) - Call options
 
   ## Returns
@@ -1834,7 +1835,7 @@ defmodule GoogleApi.Firestore.V1.Api.Projects do
       *   `:quotaUser` (*type:* `String.t`) - Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.
       *   `:uploadType` (*type:* `String.t`) - Legacy upload protocol for media (e.g. "media", "multipart").
       *   `:upload_protocol` (*type:* `String.t`) - Upload protocol for media (e.g. "raw", "multipart").
-      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.GoogleLongrunningCancelOperationRequest.t`) - 
+      *   `:body` (*type:* `GoogleApi.Firestore.V1.Model.GoogleLongrunningCancelOperationRequest.t`) -
   *   `opts` (*type:* `keyword()`) - Call options
 
   ## Returns


### PR DESCRIPTION
While working with this API, I noticed that this spec (and likely others) are incorrect. It returns a list of `GoogleApi.Firestore.V1.Model.RunQueryResponse` structs.

The raw response from `GoogleApi.Firestore.V1.Api.Projects.firestore_projects_databases_documents_run_query` is 

```elixir 
{:ok,
 [
   %GoogleApi.Firestore.V1.Model.RunQueryResponse{
     document: %GoogleApi.Firestore.V1.Model.Document{
       createTime: ~U[2020-09-02 23:42:57.807167Z],
       fields: %{
         "UID" => %GoogleApi.Firestore.V1.Model.Value{
           arrayValue: nil,
           booleanValue: nil,
           bytesValue: nil,
           doubleValue: nil,
           geoPointValue: nil,
           integerValue: nil,
           mapValue: nil,
           nullValue: nil,
           referenceValue: nil,
           stringValue: "REDACTED",
           timestampValue: nil
         },
         "savedSearches" => %GoogleApi.Firestore.V1.Model.Value{
           arrayValue: %GoogleApi.Firestore.V1.Model.ArrayValue{values: nil},
           booleanValue: nil,
           bytesValue: nil,
           doubleValue: nil,
           geoPointValue: nil,
           integerValue: nil,
           mapValue: nil,
           nullValue: nil,
           referenceValue: nil,
           stringValue: nil,
           timestampValue: nil
         }
       },
       name: "REDACTED",
       updateTime: ~U[2020-10-19 20:17:43.477743Z]
     },
     readTime: ~U[2021-06-02 19:04:32.970584Z],
     skippedResults: nil,
     transaction: nil
   }
 ]}
```