### PR TITLE
fix(gax): Correct typespecs for Connection.execute/2 and Response.decode/2

### DIFF
--- a/clients/gax/lib/google_api/gax/connection.ex
+++ b/clients/gax/lib/google_api/gax/connection.ex
@@ -93,7 +93,8 @@ defmodule GoogleApi.Gax.Connection do
       *   `{:ok, Tesla.Env.t}` - If the call was successful
       *   `{:error, reason}` - If the call failed
       """
-      @spec execute(Tesla.Client.t(), GoogleApi.Gax.Request.t()) :: {:ok, Tesla.Env.t()}
+      @spec execute(Tesla.Client.t(), GoogleApi.Gax.Request.t()) ::
+              {:ok, Tesla.Env.t()} | {:error, any()}
       def execute(connection, request) do
         request
         |> GoogleApi.Gax.Connection.build_request()

--- a/clients/gax/lib/google_api/gax/response.ex
+++ b/clients/gax/lib/google_api/gax/response.ex
@@ -32,10 +32,10 @@ defmodule GoogleApi.Gax.Response do
 
   ## Returns
 
-  *   `{:ok, struct()}` on success
+  *   `{:ok, any()}` on success
   *   `{:error, Tesla.Env.t}` on failure
   """
-  @spec decode({:ok, Tesla.Env.t()}, keyword()) :: {:ok, struct()} | {:error, Tesla.Env.t()}
+  @spec decode({:ok, Tesla.Env.t()}, keyword()) :: {:ok, any()} | {:error, Tesla.Env.t()}
   def decode(env, opts \\ [])
 
   def decode({:error, reason}, _), do: {:error, reason}


### PR DESCRIPTION
While working with the API today I noticed that these typespecs were incorrect (Dialyzer was flagging errors in my app about clauses being impossible to match.)

The docs were mostly correct, but for Response.decode/2, if no struct is provided as an option then the raw decoded value is returned instead of a struct (which could be anything).