### PR TITLE
chore: Update dependencies for gax

### DIFF
--- a/clients/gax/config/config.exs
+++ b/clients/gax/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/clients/gax/config/dev.exs
+++ b/clients/gax/config/dev.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/clients/gax/config/test.exs
+++ b/clients/gax/config/test.exs
@@ -1,3 +1,3 @@
-use Mix.Config
+import Config
 
 config :tesla, TestClient.Connection, adapter: Tesla.Mock

--- a/clients/gax/mix.exs
+++ b/clients/gax/mix.exs
@@ -28,7 +28,7 @@ defmodule GoogleApi.Gax.MixProject do
     [
       {:tesla, "~> 1.2"},
       {:mime, "~> 1.0"},
-      {:poison, ">= 3.0.0 and < 5.0.0"},
+      {:poison, ">= 3.0.0 and <= 5.0.0"},
       {:ex_doc, "~> 0.16", only: :dev},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false}
     ]

--- a/clients/gax/mix.exs
+++ b/clients/gax/mix.exs
@@ -27,7 +27,6 @@ defmodule GoogleApi.Gax.MixProject do
   defp deps() do
     [
       {:tesla, "~> 1.2"},
-      {:mime, "~> 1.0"},
       {:poison, ">= 3.0.0 and <= 5.0.0"},
       {:ex_doc, "~> 0.16", only: :dev},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false}

--- a/clients/gax/mix.exs
+++ b/clients/gax/mix.exs
@@ -29,7 +29,7 @@ defmodule GoogleApi.Gax.MixProject do
       {:tesla, "~> 1.2"},
       {:poison, ">= 3.0.0 and <= 5.0.0"},
       {:ex_doc, "~> 0.16", only: :dev},
-      {:dialyxir, "~> 0.5", only: [:dev], runtime: false}
+      {:dialyxir, ">= 0.0.0", only: [:dev, :test], runtime: false}
     ]
   end
 

--- a/clients/gax/mix.exs
+++ b/clients/gax/mix.exs
@@ -7,7 +7,7 @@ defmodule GoogleApi.Gax.MixProject do
     [
       app: :google_gax,
       version: @version,
-      elixir: "~> 1.6",
+      elixir: "~> 1.9",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       description: description(),

--- a/clients/gax/mix.exs
+++ b/clients/gax/mix.exs
@@ -28,7 +28,7 @@ defmodule GoogleApi.Gax.MixProject do
     [
       {:tesla, "~> 1.2"},
       {:poison, ">= 3.0.0 and <= 5.0.0"},
-      {:ex_doc, "~> 0.16", only: :dev},
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:dialyxir, ">= 0.0.0", only: [:dev, :test], runtime: false}
     ]
   end

--- a/clients/gax/test/gax/api_test.exs
+++ b/clients/gax/test/gax/api_test.exs
@@ -35,7 +35,7 @@ defmodule Gax.ApiTest do
     mock(fn %{
               method: :get,
               url: "https://example.com/v1/stores/store-1/pets",
-              headers: [{"x-goog-api-client", ^api_client}]
+              headers: [{"x-goog-api-client", ^api_client} | _]
             } ->
       %Tesla.Env{status: 200, body: @pets_json}
     end)
@@ -61,10 +61,13 @@ defmodule Gax.ApiTest do
     mock(fn %{
               method: :get,
               url: "https://example.com/v1/stores/store-1/pets",
-              headers: [{"x-goog-api-client", ^api_client}]
+              headers: [{"x-goog-api-client", ^api_client} | _]
             } ->
-      %Tesla.Env{status: 200, body: @pets_json_compressed,
-                 headers: [{"content-encoding", "gzip"}]}
+      %Tesla.Env{
+        status: 200,
+        body: @pets_json_compressed,
+        headers: [{"content-encoding", "gzip"}]
+      }
     end)
 
     conn = TestClient.Connection.new()


### PR DESCRIPTION
There are two main reasons for this PR.

1. There was a security problem reported in https://github.com/googleapis/elixir-google-api/pull/10753 that seems to have gone stale. This PR does the same change for gax.
2. Because the dependencies in gax are old they are preventing some newer dependencies in our project (a combination of tesla, gun, mime).