### PR TITLE
fix(gax): invalid spec in Connection/Response modules

### DIFF
--- a/clients/gax/lib/google_api/gax/connection.ex
+++ b/clients/gax/lib/google_api/gax/connection.ex
@@ -93,7 +93,7 @@ defmodule GoogleApi.Gax.Connection do
       *   `{:ok, Tesla.Env.t}` - If the call was successful
       *   `{:error, reason}` - If the call failed
       """
-      @spec execute(Tesla.Client.t(), GoogleApi.Gax.Request.t()) :: {:ok, Tesla.Env.t()}
+      @spec execute(Tesla.Client.t(), GoogleApi.Gax.Request.t()) :: Tesla.Env.result()
       def execute(connection, request) do
         request
         |> GoogleApi.Gax.Connection.build_request()

--- a/clients/gax/lib/google_api/gax/response.ex
+++ b/clients/gax/lib/google_api/gax/response.ex
@@ -24,7 +24,7 @@ defmodule GoogleApi.Gax.Response do
 
   ## Parameters
 
-  *   `response` (*type:* `{:ok, Tesla.Env.t} | {:error, reason}`) - The response object
+  *   `response` (*type:* `Testla.Env.result()`) - The response object
   *   `opts` (*type:* `keyword()`) - [optional] Optional parameters
       *   `:dataWrapped` (*type:* `boolean()`) - If true, the remove the wrapping "data" field. Defaults to false.
       *   `:decode` (*type:* `boolean()`) - If false, returns the entire reponse. Defaults to true.
@@ -32,10 +32,10 @@ defmodule GoogleApi.Gax.Response do
 
   ## Returns
 
-  *   `{:ok, struct()}` on success
-  *   `{:error, Tesla.Env.t}` on failure
+  *   `{:ok, nil | struct()}` on success
+  *   `{:error, any() | Tesla.Env.t}` on failure
   """
-  @spec decode({:ok, Tesla.Env.t()}, keyword()) :: {:ok, struct()} | {:error, Tesla.Env.t()}
+  @spec decode(Tesla.Env.result(), keyword()) :: {:ok, nil | struct()} | {:error, any() | Tesla.Env.t()}
   def decode(env, opts \\ [])
 
   def decode({:error, reason}, _), do: {:error, reason}


### PR DESCRIPTION
Hello 👋 

Specs in connection.ex and response.ex are not correct. It may trigger invalid dialyzer warnings in apps, which may lead to remove necessary code.

For example, for this piece of code:

```elixir
case Client.indexing_url_notifications_publish( connection, [ {:body, payload} ]) do
  {:ok, _} -> :ok
  {:error, %{status: 429}} -> {:discard, "Rate-limiting error, please check the quota."}
  {:error, :timeout} -> ...
end
```

For the clause `{:error, :timeout}`, dialyzer says `The pattern can never match the type`. However, it is possible to have `{:error, :timeout}` when Connection fails (because of a timeout).

You can verify with this doc: https://hexdocs.pm/tesla/Tesla.html#request/2