### PR TITLE
chore: Switch generator pull request management to auto-approve

### DIFF
--- a/.github/auto-approve.yml
+++ b/.github/auto-approve.yml
@@ -1,0 +1,2 @@
+processes:
+  - "RubyApiaryCodegen"

--- a/.github/workflows/dailly-generate-updates.yml
+++ b/.github/workflows/dailly-generate-updates.yml
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       GITHUB_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
-      APPROVAL_GITHUB_TOKEN: ${{secrets.YOSHI_APPROVER_TOKEN}}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/generate-updates.yml
+++ b/.github/workflows/generate-updates.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       GITHUB_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
-      APPROVAL_GITHUB_TOKEN: ${{secrets.YOSHI_APPROVER_TOKEN}}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.toys/generate-updates.rb
+++ b/.toys/generate-updates.rb
@@ -86,12 +86,13 @@ def handle_package api_name, index, total
     puts "(#{index}/#{total}) Pull request already exists for #{api_name}", :yellow
     return
   end
-  approval_message = "Rubber-stamped client auto-generation!"
+  approval_message = approval_token ? "Rubber-stamped client auto-generation!" : nil
+  labels = approval_token ? ["automerge: exact"] : nil
   result = yoshi_pr_generator.capture enabled: !git_remote.nil?,
                                       remote: git_remote,
                                       branch_name: branch_name,
                                       commit_message: commit_message,
-                                      labels: ["automerge"],
+                                      labels: labels,
                                       cooldown_wait: 15,
                                       auto_approve: approval_message,
                                       approval_token: approval_token do


### PR DESCRIPTION
The `YOSHI_APPROVER_TOKEN` is defunct and no longer works. This PR stops attempting to pass it into the generator. Instead, configured the auto-approve bot to handle autoapprove and automerge.

This should not be merged until https://github.com/googleapis/repo-automation-bots/pull/5387 is merged and the auto-approve bot is redeployed.