### PR TITLE
fix: relax poison and mime gax dependencies

### DIFF
--- a/clients/gax/mix.exs
+++ b/clients/gax/mix.exs
@@ -27,8 +27,8 @@ defmodule GoogleApi.Gax.MixProject do
   defp deps() do
     [
       {:tesla, "~> 1.2"},
-      {:mime, "~> 1.0"},
-      {:poison, ">= 3.0.0 and < 5.0.0"},
+      {:mime, "~> 1.0 or ~> 2.0"},
+      {:poison, ">= 3.0.0 and < 7.0.0"},
       {:ex_doc, "~> 0.16", only: :dev},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false}
     ]

--- a/clients/gax/test/gax/api_test.exs
+++ b/clients/gax/test/gax/api_test.exs
@@ -35,7 +35,7 @@ defmodule Gax.ApiTest do
     mock(fn %{
               method: :get,
               url: "https://example.com/v1/stores/store-1/pets",
-              headers: [{"x-goog-api-client", ^api_client}]
+              headers: [{"x-goog-api-client", ^api_client}, {"accept-encoding", "gzip, deflate, identity"}]
             } ->
       %Tesla.Env{status: 200, body: @pets_json}
     end)
@@ -61,7 +61,7 @@ defmodule Gax.ApiTest do
     mock(fn %{
               method: :get,
               url: "https://example.com/v1/stores/store-1/pets",
-              headers: [{"x-goog-api-client", ^api_client}]
+              headers: [{"x-goog-api-client", ^api_client}, {"accept-encoding", "gzip, deflate, identity"}]
             } ->
       %Tesla.Env{status: 200, body: @pets_json_compressed,
                  headers: [{"content-encoding", "gzip"}]}


### PR DESCRIPTION
This allows compatibility with other projects that require later versions of the poison and mime libraries.

Also fixed a couple of tests that were not accounting for the "accept-encoding" header that Tesla sends.