### PR TITLE
fix(gax): use string field names for Tesla.Multipart

### DIFF
--- a/clients/gax/lib/google_api/gax/connection.ex
+++ b/clients/gax/lib/google_api/gax/connection.ex
@@ -178,22 +178,27 @@ defmodule GoogleApi.Gax.Connection do
 
     {meta, body_params} = extract_metadata(body_params)
 
-    body = case meta do
-      nil -> body
-      _   -> Tesla.Multipart.add_field(
-        body,
-        :metadata,
-        Poison.encode!(meta),
-        headers: [{:"Content-Type", "application/json"}]
-      )
-    end
+    body =
+      case meta do
+        nil ->
+          body
+
+        _ ->
+          Tesla.Multipart.add_field(
+            body,
+            "metadata",
+            Poison.encode!(meta),
+            headers: [{:"Content-Type", "application/json"}]
+          )
+      end
 
     body =
       Enum.reduce(body_params, body, fn {body_name, data}, b ->
         {res, type} = try_encode_multipart_field(data, meta)
+
         Tesla.Multipart.add_field(
           b,
-          body_name,
+          to_string(body_name),
           res,
           headers: [{:"Content-Type", type}]
         )
@@ -201,7 +206,7 @@ defmodule GoogleApi.Gax.Connection do
 
     body =
       Enum.reduce(file_params, body, fn {file_name, file_path}, b ->
-        Tesla.Multipart.add_file(b, file_path, name: file_name)
+        Tesla.Multipart.add_file(b, file_path, name: to_string(file_name))
       end)
 
     Keyword.put(output, :body, body)


### PR DESCRIPTION
Tesla.Multipart expects string field/file names. Convert atom names to strings via to_string/1 and use "metadata" instead of :metadata.